### PR TITLE
use builtin typed_ast when Python version>=3.8

### DIFF
--- a/python/matx/_typed_ast.py
+++ b/python/matx/_typed_ast.py
@@ -1,0 +1,30 @@
+# Copyright 2022 ByteDance Ltd. and/or its affiliates.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+"""
+In python 3.8 or higher, it is recommended to use builtin ast module as described https://github.com/python/typed_ast.
+In python 3.7 or lower, we use typed_ast. This module is to provide a common interface to import ast
+"""
+
+import sys
+
+if sys.version_info.minor < 8:
+    from typed_ast import ast3 as ast
+else:
+    import ast

--- a/python/matx/ir/type_converter.py
+++ b/python/matx/ir/type_converter.py
@@ -21,7 +21,7 @@
 import inspect
 from functools import lru_cache
 import types
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from typing import Optional
 
 from . import type as _ty

--- a/python/matx/script/analysis/__init__.py
+++ b/python/matx/script/analysis/__init__.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 
 from .. import context
 

--- a/python/matx/script/analysis/_abstract_checker.py
+++ b/python/matx/script/analysis/_abstract_checker.py
@@ -20,7 +20,7 @@
 import abc
 import inspect
 
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from ..reporter import Reporter
 from ..context import Span
 from ...contrib.inspect3_9_1_patch import getsourcelines, findsource, getabsfile

--- a/python/matx/script/analysis/class_analysis.py
+++ b/python/matx/script/analysis/class_analysis.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from typing import Any
 import inspect
 

--- a/python/matx/script/analysis/deps_analysis.py
+++ b/python/matx/script/analysis/deps_analysis.py
@@ -23,7 +23,7 @@ from typing import List
 import builtins
 import inspect
 import sys
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 
 from .. import context
 from ._python_builtin_module import is_builtin_module

--- a/python/matx/script/analysis/function_analysis.py
+++ b/python/matx/script/analysis/function_analysis.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 import inspect
 from typing import List
 

--- a/python/matx/script/analysis/inheritence_consistency_check.py
+++ b/python/matx/script/analysis/inheritence_consistency_check.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import Dict, List
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from inspect import getmro, isclass
 from .. import context
 from ..reporter import raise_syntax_error

--- a/python/matx/script/analysis/source_analysis.py
+++ b/python/matx/script/analysis/source_analysis.py
@@ -18,7 +18,7 @@
 # under the License.
 
 import re
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 
 from .. import context
 from ..reporter import raise_syntax_error

--- a/python/matx/script/analysis/syntax_check.py
+++ b/python/matx/script/analysis/syntax_check.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from typing import Dict, List, Optional
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from .. import context
 from ..reporter import raise_syntax_error, unsupported_syntax_error_table, INVALID_ITERATOR_METHODS
 

--- a/python/matx/script/context/ast_node.py
+++ b/python/matx/script/context/ast_node.py
@@ -19,7 +19,7 @@
 import inspect
 from typing import Callable, Optional, Tuple, Union, List, Dict, Any, Iterable, Set
 from queue import Queue
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from .class_context import ClassContext
 from .function_context import FunctionContext
 from ... import ir as _ir

--- a/python/matx/script/parser.py
+++ b/python/matx/script/parser.py
@@ -24,7 +24,7 @@ import builtins
 import sys
 
 from typing import Any, Union, List, Optional
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 
 from .reporter.script_error import MATXScriptError
 

--- a/python/matx/script/reporter/reporter.py
+++ b/python/matx/script/reporter/reporter.py
@@ -16,7 +16,7 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 from .. import context
 from typing import Optional
 

--- a/python/matx/script/transforms/if_bool.py
+++ b/python/matx/script/transforms/if_bool.py
@@ -28,7 +28,7 @@
 
 from .. import context
 from typing import List
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 import logging
 import copy
 

--- a/python/matx/script/transforms/normalize_name.py
+++ b/python/matx/script/transforms/normalize_name.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 from .. import context
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 import logging
 import copy
 

--- a/python/matx/script/transforms/rename_attrs.py
+++ b/python/matx/script/transforms/rename_attrs.py
@@ -28,7 +28,7 @@
 
 from .. import context
 from typing import List
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 import logging
 import copy
 

--- a/python/matx/script/transforms/rename_super.py
+++ b/python/matx/script/transforms/rename_super.py
@@ -20,7 +20,7 @@
 from .. import context
 from ..reporter import raise_syntax_error
 from typing import List, Optional, Tuple
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 import copy
 
 

--- a/python/matx/script/type_parser.py
+++ b/python/matx/script/type_parser.py
@@ -17,7 +17,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-from typed_ast import ast3 as ast
+from matx._typed_ast import ast
 
 from . import context
 from .reporter import MATXScriptError

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,4 +1,4 @@
 numpy>=1.6,<2.0.0
-typed_ast~=1.4.2
+typed_ast~=1.4.2; python_version<'3.8'
 astpretty>=1.0,<3.0.0
 prettytable>=1.0,<4.0.0


### PR DESCRIPTION
Modify python/requirements.txt. Use builtin typed_ast when Python version>=3.8 as suggested by https://github.com/python/typed_ast