### PR TITLE
Support tracing for class method, fix various issues 

### DIFF
--- a/.github/workflows/check_cc_codestyle.yml
+++ b/.github/workflows/check_cc_codestyle.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+    - name: Prepare clang-tools-10
+      run: sudo apt-get -y install clang-format-10
     - name: checkout
       run: |
         commits=${{ github.event.pull_request.commits }}

--- a/.github/workflows/check_cc_codestyle.yml
+++ b/.github/workflows/check_cc_codestyle.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Prepare clang-tools-10
-      run: sudo apt-get -y install clang-format-10
+      run: echo "TODO install clang-tools-10"
     - name: checkout
       run: |
         commits=${{ github.event.pull_request.commits }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+tempdir
 code_review
 *log
 .bundle

--- a/ci/code-format-cxx.sh
+++ b/ci/code-format-cxx.sh
@@ -21,6 +21,8 @@
 THIS_PATH=$(cd $(dirname "$0"); pwd)
 ROOT_PATH=${THIS_PATH}/../
 
+export PATH=$THIS_PATH/clang-tools:$PATH
+
 # hack for code format
 if [ -f "${THIS_PATH}/pre-commit" ];then
     cp ${THIS_PATH}/pre-commit ${ROOT_PATH}/.git/hooks/pre-commit

--- a/include/matxscript/runtime/py_commons/pyconfig.h
+++ b/include/matxscript/runtime/py_commons/pyconfig.h
@@ -42,7 +42,9 @@
 /* Define if we can use gcc inline assembler to get and set x87 control word
  */
 #ifndef MATX_BUILD_MICRO_RUNTIME
+#ifndef __aarch64__  // if it is an arm processor, it doesn't support asm for x87
 #define HAVE_GCC_ASM_FOR_X87 1
+#endif
 #endif
 
 /* Define if your compiler provides __uint128_t */

--- a/python/matx/pipeline/jit_object.py
+++ b/python/matx/pipeline/jit_object.py
@@ -182,9 +182,16 @@ def restore_user_behavior(ud: JitObject,
                 if raw_name == "__init__":
                     continue
                 bound_self = fm.bound_self
-                pf_func = ud.get_function(func_name)
 
-                user_func = _make_user_func(raw_name, bound_self, self_obj, pf_func)
+                # pf_func = ud.get_function(func_name)
+                # user_func = _make_user_func(raw_name, bound_self, self_obj, pf_func)
+
+                if raw_name == '__call__':
+                    raw_name = 'native_call_method'
+
+                pf_func = JitOpImpl(main_func_name=func_name, jit_object=ud)
+                user_func = _make_user_func(raw_name, False, self_obj, pf_func)
+
                 setattr(ud, raw_name, user_func)
     else:
         func_name = init_schema.name

--- a/python/matx/pipeline/jit_object.py
+++ b/python/matx/pipeline/jit_object.py
@@ -185,8 +185,10 @@ def restore_user_behavior(ud: JitObject,
                 pf_func = JitOpImpl(main_func_name=func_name, jit_object=ud)
                 user_func = _make_user_func(raw_name, pf_func)
 
-                setattr(ud, raw_name, user_func)  # rebound the user function
-                ud.op_mapping_2_71828182846[raw_name] = pf_func  # bound the JitOpImpl into JitObject
+                # rebound the user function
+                setattr(ud, raw_name, user_func)
+                # bound the JitOpImpl into JitObject
+                ud.op_mapping_2_71828182846[raw_name] = pf_func
     else:
         func_name = init_schema.name
         pf_func = ud.get_function(func_name)

--- a/python/matx/pipeline/module.py
+++ b/python/matx/pipeline/module.py
@@ -285,7 +285,6 @@ class JITModule(Module):
     def __call__(self, **kwargs):
         return self.run(kwargs)
 
-
     def run(self, feed_dict):
         """Execute Pipeline and get output
 

--- a/python/matx/pipeline/module.py
+++ b/python/matx/pipeline/module.py
@@ -282,6 +282,10 @@ class JITModule(Module):
         warnings.warn("The function JITModule.Run is deprecated.", DeprecationWarning)
         return self.run(feed_dict)
 
+    def __call__(self, **kwargs):
+        return self.run(kwargs)
+
+
     def run(self, feed_dict):
         """Execute Pipeline and get output
 

--- a/python/matx/script/analysis/build_type_analysis.py
+++ b/python/matx/script/analysis/build_type_analysis.py
@@ -29,10 +29,7 @@ class BuildTypeAnalysis:
         self.change = False
         node_ctx = sc_ctx.main_node.context
         if isinstance(node_ctx, context.ClassContext):
-            if '__call__' in node_ctx.methods:
-                build_type = context.BuildType.JIT_OP
-            else:
-                build_type = context.BuildType.JIT_OBJECT
+            build_type = context.BuildType.JIT_OBJECT
         elif isinstance(node_ctx, context.FunctionContext):
             build_type = context.BuildType.FUNCTION
         else:

--- a/python/matx/script/context/build_type.py
+++ b/python/matx/script/context/build_type.py
@@ -22,5 +22,5 @@ import enum
 
 class BuildType(enum.Enum):
     FUNCTION = enum.auto()  # pure function
-    JIT_OP = enum.auto()  # class with __call__
+    JIT_OP = enum.auto()  # class with __call__. TODO: deprecate JIT_OP. Only used in toolchain.make_session
     JIT_OBJECT = enum.auto()  # general class

--- a/python/matx/script/context/build_type.py
+++ b/python/matx/script/context/build_type.py
@@ -22,5 +22,4 @@ import enum
 
 class BuildType(enum.Enum):
     FUNCTION = enum.auto()  # pure function
-    JIT_OP = enum.auto()  # class with __call__. TODO: deprecate JIT_OP. Only used in toolchain.make_session
     JIT_OBJECT = enum.auto()  # general class

--- a/python/matx/toolchain.py
+++ b/python/matx/toolchain.py
@@ -379,8 +379,6 @@ def script(compiling_obj, *, share=True, toolchain=None, bundle_args=None):
         return make_jit_op_creator(result, share, bundle_args=bundle_args)()
     elif result.build_type is context.BuildType.JIT_OBJECT:
         return make_jit_object_creator(result, share, bundle_args=bundle_args)
-    elif result.build_type is context.BuildType.JIT_OP:
-        return make_jit_op_creator(result, share, bundle_args=bundle_args)
     else:
         raise ValueError('Unsupported build_type: {}'.format(result.build_type))
 

--- a/test/script/test_tracing_class_method.py
+++ b/test/script/test_tracing_class_method.py
@@ -1,0 +1,86 @@
+# Copyright 2022 ByteDance Ltd. and/or its affiliates.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+import random
+import unittest
+import matx
+
+
+class Counter:
+    """
+    This class contains method that modifies a class member, and contains native __call__ method to test compatibility
+    """
+
+    def __init__(self, init_value: int) -> None:
+        self.value: int = init_value
+
+    def minus(self, a: int) -> int:
+        self.value = self.value - a
+        return self.value
+
+    def add(self, a: int) -> int:
+        self.value = self.value + a
+        return self.value
+
+    def __call__(self, a: int) -> int:
+        self.value = self.value * a + a
+        return self.value
+
+
+class WorkFlow:
+    def __init__(self, init_value=10, script=True):
+        # create a foo instance
+        if script:
+            self.foo = matx.script(Counter)(init_value)
+        else:
+            self.foo = Counter(init_value=init_value)
+
+    def process(self, a: int) -> int:
+        # start to build computational graph
+        # do some complicated things with c
+        # d = do_something(c)
+        d = self.foo(a)
+        c = self.foo.minus(d)
+        return self.foo.add(c)
+
+
+class TestTracingClassMethod(unittest.TestCase):
+    def test_tracing_class_method(self):
+        init_value = 0
+
+        workflow_matx = WorkFlow(init_value=init_value, script=True)
+        workflow_process_mod = matx.trace(workflow_matx.process, 1)
+
+        workflow_py = WorkFlow(init_value=init_value, script=False)
+        workflow_py.process(1)  # to match up with trace side effects
+
+        # generate random number and test
+        test_steps = 100
+        for _ in range(test_steps):
+            random_int = random.randint(-10, 10)
+            py_result = workflow_py.process(random_int)
+            matx_result = workflow_process_mod(a=random_int)
+
+            self.assertEqual(py_result, matx_result)
+
+
+if __name__ == '__main__':
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/test/trace/test_common_trace.py
+++ b/test/trace/test_common_trace.py
@@ -203,6 +203,19 @@ class TestCommonTrace(unittest.TestCase):
         assert sess.run({'x': 2}) == 9
         assert sess.input_names == ['x']
 
+    def test_make_session_by_one_class_method(self):
+
+        class AddX:
+            def __init__(self, x: int) -> None:
+                self._x: int = x
+
+            def add(self, x: int) -> int:
+                return self._x + x
+
+        sess = matx.toolchain.make_session(AddX, method='add')(7)
+        assert sess.run({'x': 2}) == 9
+        assert sess.input_names == ['x']
+
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
1. Support tracing for class method
2. Deprecate JITOp enum
3. Add `__call__` to JITModule as alias for run method
4. Add `__aarch64__` macro in include/matxscript/runtime/py_commons/pyconfig.h to support build on macOS m1