### PR TITLE
[script]ndarray constructor: support Any type

### DIFF
--- a/python/matx/ir/builtin2op.py
+++ b/python/matx/ir/builtin2op.py
@@ -450,7 +450,9 @@ def _register_nd_array_construct():
             elif isinstance(e.checked_type, _type.ObjectType):
                 return _to_unicode_ir(span, e)
             else:
-                raise TypeError("ndarray constructor: type of parameter %s should be Unicode, but get %s" % (name, e.checked_type))
+                raise TypeError(
+                    "ndarray constructor: type of parameter %s should be Unicode, but get %s" %
+                    (name, e.checked_type))
 
         if not isinstance(device, _expr.BaseExpr):
             assert isinstance(device, str), "internal error"
@@ -471,7 +473,9 @@ def _register_nd_array_construct():
         elif isinstance(shape.checked_type, _type.ObjectType):
             shape = Builtin2Op.lookup("list")(span, shape)
         else:
-            raise TypeError("ndarray constructor: type of parameter shape should be list, but get %s" % shape.checked_type)
+            raise TypeError(
+                "ndarray constructor: type of parameter shape should be list, but get %s" %
+                shape.checked_type)
 
         dtype = convert_unicode(span, dtype, 'dtype')
         device = convert_unicode(span, device, 'device')

--- a/python/matx/ir/builtin2op.py
+++ b/python/matx/ir/builtin2op.py
@@ -444,6 +444,14 @@ def _register_nd_array_construct():
                            shape,
                            dtype,
                            device="cpu"):
+        def convert_unicode(span, e, name):
+            if isinstance(e.checked_type, _type.UnicodeType):
+                return e
+            elif isinstance(e.checked_type, _type.ObjectType):
+                return _to_unicode_ir(span, e)
+            else:
+                raise TypeError("ndarray constructor: type of parameter %s should be Unicode, but get %s" % (name, e.checked_type))
+
         if not isinstance(device, _expr.BaseExpr):
             assert isinstance(device, str), "internal error"
             device = _expr.UnicodeImm(device, span=span)
@@ -458,6 +466,16 @@ def _register_nd_array_construct():
         #     checked_dtype = _type.PrimType(dtype.value)
         # ret_ty = _type.NDArrayType(ndim=ndim, dtype=checked_dtype)
         ret_ty = _type.NDArrayType()
+        if isinstance(shape.checked_type, _type.ListType):
+            pass
+        elif isinstance(shape.checked_type, _type.ObjectType):
+            shape = Builtin2Op.lookup("list")(span, shape)
+        else:
+            raise TypeError("ndarray constructor: type of parameter shape should be list, but get %s" % shape.checked_type)
+
+        dtype = convert_unicode(span, dtype, 'dtype')
+        device = convert_unicode(span, device, 'device')
+
         return _ir_adt.Constructor("NDArray", ret_type=ret_ty)(
             span,
             arr,

--- a/test/script/test_ndarray_constructor.py
+++ b/test/script/test_ndarray_constructor.py
@@ -123,6 +123,21 @@ class TestMatxNDArrayConstructor(unittest.TestCase):
         np_nd = numpy.ones(shape=[2, 2], dtype="int64")
         self.assertTrue(numpy.all(mx_nd.asnumpy().astype(dtype="int64") == np_nd))
 
+    def test_construct_with_any_shape(self):
+        def build_ndarray() -> matx.NDArray:
+            shape: Any = [2, 2]
+            return matx.NDArray([1, 2, 3, 4], shape, "int32")
+        py_nd = build_ndarray()
+        matx_nd = matx.script(build_ndarray)()
+        self.assertTrue(numpy.array_equal(py_nd.asnumpy(), matx_nd.asnumpy()))
+
+    def test_construct_with_invalid_shape(self):
+        def build_ndarray() -> matx.NDArray:
+            data = [[1, 2], [3, 4]]
+            shape = (2, 2)
+            return matx.NDArray(data, shape, dtype='int32')
+        self.assertRaises(Exception, matx.script, build_ndarray)
+
 
 if __name__ == "__main__":
     import logging


### PR DESCRIPTION
- ndarray constructor: support `shape`  is type `any` during compiling
- ndarray constructor: report error when type of `shape` is invalid ( #64 )