### PR TITLE
[torch] improve errmsg when torch report an error

### DIFF
--- a/include/matxscript/runtime/c_runtime_api.h
+++ b/include/matxscript/runtime/c_runtime_api.h
@@ -507,12 +507,14 @@ typedef void (*MATXScriptPackedCFuncFinalizer)(void* resource_handle);
  * \param resource_handle The resource handle from front-end, can be NULL.
  * \param fin The finalizer on resource handle when the FunctionHandle get freed, can be NULL
  * \param out the result function handle.
+ * \param do_stack_trace_on_error
  * \return 0 when success, -1 when failure happens
  */
 MATX_DLL int MATXScriptFuncCreateFromCFunc(MATXScriptPackedCFunc func,
                                            void* resource_handle,
                                            MATXScriptPackedCFuncFinalizer fin,
-                                           MATXScriptFunctionHandle* out);
+                                           MATXScriptFunctionHandle* out,
+                                           int do_stack_trace_on_error);
 
 /*!
  * \brief Register the function to runtime's global table.

--- a/python/matx/_ffi/_c_ext/fast_c_api.cc
+++ b/python/matx/_ffi/_c_ext/fast_c_api.cc
@@ -1283,7 +1283,8 @@ static PyObject* matx_script_api_convert_to_packed_func(PyObject* self, PyObject
   if (0 != MATXScriptFuncCreateFromCFunc(PythonClosureMATXScriptPackedCFunc,
                                          py_func,
                                          PythonClosureMATXScriptPackedCFuncFinalizer,
-                                         &handle)) {
+                                         &handle,
+                                         0)) {
     PyErr_SetString(PyExc_TypeError, MATXScriptAPIGetLastError());
     return NULL;
   }


### PR DESCRIPTION
- related issue: #64 

> fix matx.script(model) will hide the error message of a pytorch model


```text
Traceback (most recent call last):
  File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/test_torch.py", line 49, in <module>
    data = process(x, h)
  File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/test_torch.py", line 45, in process
    h1, h2 = torch_model(x, h)
  File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/matx/extension/pytorch/pytorch_module.py", line 170, in __call__
    return super(PyTorchInferOp, self).__call__(*args, **kwargs)
  File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/matx/pipeline/ops.py", line 112, in __call__
    res_pack, type_code = op_kernel_call(self.native_op_handle, *args)
TypeError:   File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/matx/extension/pytorch/pytorch_module.py", line 377, in __call__
    model_output = self._model(*args_data)
  File "/opt/anaconda3/envs/py39/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1190, in _call_impl
    return forward_call(*input, **kwargs)
  File "/Users/bytedance/Desktop/maxiandi/github/matxscript/python/test_torch.py", line 34, in forward
    d = a.to(1)
AttributeError: 'bool' object has no attribute 'to'
```