### PR TITLE
[pipeline] show human name in timeline

### DIFF
--- a/include/matxscript/pipeline/interpreter_op.h
+++ b/include/matxscript/pipeline/interpreter_op.h
@@ -100,6 +100,8 @@ class InterpreterOp : public OpKernel {
 
   void Init() override;
 
+  String GetHumanName(bool with_debug_info) const;
+
  public:
   RTValue Process(PyArgs inputs) const override;
 

--- a/include/matxscript/pipeline/jit_object.h
+++ b/include/matxscript/pipeline/jit_object.h
@@ -104,6 +104,8 @@ class JitObject : public OpKernel {
     std::vector<std::pair<String, String>> captures;
     bool is_class = false;
     bool share = true;
+    int64_t py_source_line_ = -1;
+    String py_source_file_;
 
     static Options FromDict(const Dict& config);
     Dict ToDict() const;

--- a/include/matxscript/pipeline/jit_op.h
+++ b/include/matxscript/pipeline/jit_op.h
@@ -35,6 +35,8 @@ class JitOp : public OpKernel {
 
   RTValue generic_call_attr(string_view func_name, PyArgs args);
 
+  String GetHumanName(bool with_debug_info) const;
+
  protected:
   String main_func_name_;
   String jit_object_name_;

--- a/include/matxscript/pipeline/tx_session.h
+++ b/include/matxscript/pipeline/tx_session.h
@@ -187,7 +187,7 @@ struct TXSession {
  private:
   class TXSessionRunnable;
   class TXSessionWarmupRunnable;
-  static TXSessionStepStat MakeSessionStepStat(const OpKernel* op);
+  static TXSessionStepStat MakeSessionStepStat(const NodePtr& op);
   void RunImpl(const std::unordered_map<std::string, RTValue>& feed_dict,
                std::vector<std::pair<std::string, RTValue>>& result,
                TXSessionRunMeta* meta = nullptr) const;

--- a/python/matx/pipeline/jit_object.py
+++ b/python/matx/pipeline/jit_object.py
@@ -101,7 +101,9 @@ class JitObject(OpKernel):
                  need_bundle=None,
                  function_mapping=None,
                  share=True,
-                 captures=None):
+                 captures=None,
+                 py_source_file=b"",
+                 py_source_line=-1):
         assert isinstance(function_mapping, dict)
         assert isinstance(meta_info, (ClassMeta, FuncMeta))
         if need_bundle is None:
@@ -117,7 +119,9 @@ class JitObject(OpKernel):
                                             class_info=meta_info.toobject(),
                                             need_bundle=need_bundle,
                                             share=share,
-                                            captures=captures)
+                                            captures=captures,
+                                            py_source_file=py_source_file,
+                                            py_source_line=py_source_line)
         else:
             super(JitObject, self).__init__("JitObject",
                                             dso_path=dso_path.encode(),
@@ -125,7 +129,9 @@ class JitObject(OpKernel):
                                             func_info=meta_info.toobject(),
                                             need_bundle=need_bundle,
                                             share=share,
-                                            captures=captures)
+                                            captures=captures,
+                                            py_source_file=py_source_file,
+                                            py_source_line=py_source_line)
         # TODO: add magic number
         self.function_mapping = function_mapping
         self.op_mapping_2_71828182846 = dict()
@@ -155,14 +161,8 @@ class JitObject(OpKernel):
 
 
 def _make_user_func(raw_name, pf_func):
-    @trans_exception_from_c_to_py
-    def user_func(*args, **kwargs):
-        assert len(kwargs) == 0
-        # bound self
-        return pf_func(*args)
-
-    user_func.__name__ = raw_name
-    return user_func
+    pf_func.__name__ = raw_name
+    return pf_func
 
 
 def restore_user_behavior(ud: JitObject,

--- a/python/matx/toolchain.py
+++ b/python/matx/toolchain.py
@@ -161,6 +161,8 @@ def make_jit_object_creator(sc_ctx: context.ScriptContext, share=True, bundle_ar
                 function_mapping={func_name: func_name},
                 share=share,
                 captures=captures,
+                py_source_file=sc_ctx.main_node.span.file_name.encode(),
+                py_source_line=sc_ctx.main_node.span.lineno,
             )
             ud = restore_user_behavior(ud, func_name, False, func_schema)
             ud.__name__ = sc_ctx.main_node.context.name
@@ -220,6 +222,8 @@ def make_jit_object_creator(sc_ctx: context.ScriptContext, share=True, bundle_ar
                 function_mapping=function_mapping,
                 share=share,
                 captures=captures,
+                py_source_file=sc_ctx.main_node.span.file_name.encode(),
+                py_source_line=sc_ctx.main_node.span.lineno,
             )
             ud = restore_user_behavior(ud, user_class_name, True, ctor_func_meta, member_funcs)
             ud.__name__ = sc_ctx.main_node.context.name

--- a/src/pipeline/interpreter_op.cc
+++ b/src/pipeline/interpreter_op.cc
@@ -18,9 +18,11 @@
  * under the License.
  */
 #include <matxscript/pipeline/interpreter_op.h>
+
 #include <matxscript/pipeline/node.h>
 #include <matxscript/pipeline/symbolic_executor.h>
 #include <matxscript/runtime/container/dict_private.h>
+#include <matxscript/runtime/file_util.h>
 #include <matxscript/runtime/generic/generic_constructor_funcs.h>
 #include <matxscript/runtime/generic/generic_funcs.h>
 #include <matxscript/runtime/generic/generic_hlo_arith_funcs.h>
@@ -320,6 +322,31 @@ String InterpreterOp::GenDebugMessage() const {
   message.append(", in ").append(py_source_func_).append("\n");
   message.append("  ").append(py_source_stmt_);
   return message;
+}
+
+String InterpreterOp::GetHumanName(bool with_debug_info) const {
+  String op_code_s;
+  switch (static_cast<OpCode>(opcode_)) {
+    case OpCode::ParallelMap: {
+      op_code_s = "matx.pmap";
+    } break;
+    case OpCode::ParallelStarMap: {
+      op_code_s = "matx.pstarmap";
+    } break;
+    case OpCode::ApplyAsync: {
+      op_code_s = "matx.apply_async";
+    } break;
+    default: {
+      op_code_s = OpCode2Str(opcode_);
+    } break;
+  }
+  if (with_debug_info && py_source_line_ >= 0) {
+    auto filename = FileUtil::GetFileBasename(py_source_file_);
+    auto fileline = std::to_string(py_source_line_);
+    return String(op_code_s) + " @" + filename + ":" + fileline;
+  } else {
+    return op_code_s;
+  }
 }
 
 RTValue InterpreterOp::Process(PyArgs inputs) const {

--- a/src/pipeline/jit_object.cc
+++ b/src/pipeline/jit_object.cc
@@ -197,6 +197,14 @@ JitObject::Options JitObject::Options::FromDict(const Dict& config) {
     jit_module_opts.is_class = false;
     jit_module_opts.func_info = FuncMeta::FromDict(config["func_info"].As<Dict>());
   }
+
+  // debug info
+  if (config.contains("py_source_file")) {
+    jit_module_opts.py_source_file_ = config.get_item("py_source_file").As<String>();
+  }
+  if (config.contains("py_source_line")) {
+    jit_module_opts.py_source_line_ = config.get_item("py_source_line").As<int64_t>();
+  }
   return jit_module_opts;
 }
 
@@ -229,6 +237,10 @@ Dict JitObject::Options::ToDict() const {
   } else {
     generic_object_opt["func_info"] = func_info.ToDict();
   }
+
+  // debug info
+  generic_object_opt["py_source_file"] = py_source_file_;
+  generic_object_opt["py_source_line"] = py_source_line_;
 
   return generic_object_opt;
 }

--- a/src/pipeline/jit_op.cc
+++ b/src/pipeline/jit_op.cc
@@ -77,5 +77,25 @@ RTValue JitOp::generic_call_attr(string_view func_name, PyArgs args) {
   return jit_object_->generic_call_attr(func_name, args);
 }
 
+String JitOp::GetHumanName(bool with_debug_info) const {
+  String human_name;
+  auto jit_obj_name = jit_object_->PyObjectName();
+  if (jit_object_->options_.is_class) {
+    String method_name = FunctionNameRules::remove_class_prefix(jit_obj_name, main_func_name_);
+    human_name = jit_obj_name + "." + method_name;
+  } else {
+    human_name = jit_obj_name;
+  }
+  if (with_debug_info && jit_object_->options_.py_source_line_ >= 0) {
+    auto filename = FileUtil::GetFileBasename(jit_object_->options_.py_source_file_);
+    auto fileline = std::to_string(jit_object_->options_.py_source_line_);
+    human_name.append(" @");
+    human_name.append(filename.data(), filename.size());
+    human_name.append(":");
+    human_name.append(fileline.data(), fileline.size());
+  }
+  return human_name;
+}
+
 }  // namespace runtime
 }  // namespace matxscript


### PR DESCRIPTION
- more clear op name 
   - The matx.pmap converts the op with the same names, which is kind of unreadable. ( #64 ) 


|                             op                            |      start       |       end        | time cost(ms) |   %    |
|:---------------------------------------------------------:|:----------------:|:----------------:|:-------------:|:------:|
|                       Input: queries                      |        -         |        -         |   0.0000(ms)  | 0.00%  |
|                        GetConstant                        | 03:00:000.700545 | 03:00:000.700547 |   0.0020(ms)  | 0.01%  |
|              __getitem__ @test_timeline.py:84             | 03:00:000.700547 | 03:00:000.700549 |   0.0020(ms)  | 0.01%  |
|                        GetConstant                        | 03:00:000.700549 | 03:00:000.700549 |   0.0000(ms)  | 0.00%  |
|      Mytest_make_ngram.__call__ @test_timeline.py:60      | 03:00:000.700549 | 03:00:000.722105 |  21.5560(ms)  | 97.34% |
|                        GetConstant                        | 03:00:000.722105 | 03:00:000.722105 |   0.0000(ms)  | 0.00%  |
| matx.pmap(MyFunctor.make_ngram, ...) @test_timeline.py:83 | 03:00:000.722105 | 03:00:000.722665 |   0.5600(ms)  | 2.53%  |
|                           Total                           | 03:00:000.700522 | 03:00:000.722667 |  22.1450(ms)  |  ----  |