### PR TITLE
fix compile warnning

### DIFF
--- a/include/matxscript/runtime/logging.h
+++ b/include/matxscript/runtime/logging.h
@@ -185,8 +185,7 @@ class NullStream : public std::ostream {
  public:
   NullStream() : std::ostream(nullptr) {
   }
-  NullStream(const NullStream&) : std::ostream(nullptr) {
-  }
+  NullStream(const NullStream&) = default;
 };
 
 template <class T>

--- a/include/matxscript/runtime/logging.h
+++ b/include/matxscript/runtime/logging.h
@@ -185,7 +185,7 @@ class NullStream : public std::ostream {
  public:
   NullStream() : std::ostream(nullptr) {
   }
-  NullStream(const NullStream&) = default;
+  NullStream(const NullStream&) = delete;
 };
 
 template <class T>

--- a/src/runtime/logging.cc
+++ b/src/runtime/logging.cc
@@ -33,7 +33,7 @@ namespace runtime {
 
 static int64_t logging_level = LoggingLevel::WARNING;
 
-NullStream null_stream = NullStream();
+NullStream null_stream;
 
 MATX_DLL void SetLoggingLevel(int64_t level) {
   logging_level = level;


### PR DESCRIPTION
warning: base class ‘class std::basic_ios<char>’ should be explicitly initialized in the copy constructor [-Wextra]