### PR TITLE
Add NDArray impl feature. 

### DIFF
--- a/include/matxscript/runtime/container/ndarray.h
+++ b/include/matxscript/runtime/container/ndarray.h
@@ -227,6 +227,9 @@ class NDArray : public ObjectRef {
   int64_t size() const;
   NDArray transpose(const Any& axes = None) const;
   NDArray as_type(const unicode_view& dtype_str) const;
+ 
+  int64_t GetImpl() const;
+  void SetImpl(int64_t impl);
 
  public:
   static void AssignNDArray(const NDArray& src, NDArray& dst);

--- a/include/matxscript/runtime/container/ndarray.h
+++ b/include/matxscript/runtime/container/ndarray.h
@@ -45,6 +45,8 @@ class NDArray : public ObjectRef {
   class Container;
   /*! \brief Container type for Object system. */
   using ContainerType = Container;
+  /*! \brief enum of the implementations of the NDArray. */
+  enum Impl { ndarray = 0, numpy = 1, tfTensor = 2, torchTensor = 3 };
   static constexpr bool _type_is_nullable = false;  // disable nullptr for performance
   /*! \brief default constructor */
   NDArray() noexcept = default;
@@ -228,8 +230,8 @@ class NDArray : public ObjectRef {
   NDArray transpose(const Any& axes = None) const;
   NDArray as_type(const unicode_view& dtype_str) const;
  
-  int64_t GetImpl() const;
-  void SetImpl(int64_t impl);
+  NDArray::Impl GetImpl() const;
+  void SetImpl(NDArray::Impl impl);
 
  public:
   static void AssignNDArray(const NDArray& src, NDArray& dst);

--- a/include/matxscript/runtime/container/ndarray.h
+++ b/include/matxscript/runtime/container/ndarray.h
@@ -229,7 +229,7 @@ class NDArray : public ObjectRef {
   int64_t size() const;
   NDArray transpose(const Any& axes = None) const;
   NDArray as_type(const unicode_view& dtype_str) const;
- 
+
   NDArray::Impl GetImpl() const;
   void SetImpl(NDArray::Impl impl);
 

--- a/include/matxscript/runtime/container/ndarray_private.h
+++ b/include/matxscript/runtime/container/ndarray_private.h
@@ -48,6 +48,14 @@ class NDArray::ContainerBase {
    */
   void* manager_ctx{nullptr};
 
+  /*!
+   * \brief The implementation of the container.
+   * This flag is used to implicitly convert between NDArray and
+   * np.ndarray, tf.Tensor, torch.Tensor, etc,.
+   * Mapping Table: 0: NDArray, 1: np.ndarray, 2: tf.Tensor, 3: torch.Tensor
+   */
+  int64_t impl_{0};
+ 
  protected:
   /*!
    * \brief The shape container,

--- a/include/matxscript/runtime/container/ndarray_private.h
+++ b/include/matxscript/runtime/container/ndarray_private.h
@@ -55,7 +55,7 @@ class NDArray::ContainerBase {
    * Mapping Table: 0: NDArray, 1: np.ndarray, 2: tf.Tensor, 3: torch.Tensor
    */
   Impl impl{Impl::ndarray};
- 
+
  protected:
   /*!
    * \brief The shape container,

--- a/include/matxscript/runtime/container/ndarray_private.h
+++ b/include/matxscript/runtime/container/ndarray_private.h
@@ -54,7 +54,7 @@ class NDArray::ContainerBase {
    * np.ndarray, tf.Tensor, torch.Tensor, etc,.
    * Mapping Table: 0: NDArray, 1: np.ndarray, 2: tf.Tensor, 3: torch.Tensor
    */
-  int64_t impl_{0};
+  Impl impl{Impl::ndarray};
  
  protected:
   /*!

--- a/python/matx/runtime/ndarray.py
+++ b/python/matx/runtime/ndarray.py
@@ -47,6 +47,7 @@ __all__ = [
     "from_dlpack",
 ]
 
+
 class NDArrayImpl(enum.IntEnum):
     # The Enum must be consistent with definition in C++
     NDARRAY = 0
@@ -54,9 +55,11 @@ class NDArrayImpl(enum.IntEnum):
     TF_TENSOR = 2
     TORCH_TENSOR = 3
 
+
 def _ndarray_callback(obj):
     obj.__init_self__()
     return obj._to_impl()
+
 
 @_ffi.register_object("runtime.NDArray", _ndarray_callback)
 class NDArray(Object):

--- a/src/c_api/ndarray_c_api.cc
+++ b/src/c_api/ndarray_c_api.cc
@@ -153,5 +153,18 @@ MATXSCRIPT_REGISTER_GLOBAL("runtime.NDArrayCopyToBytes").set_body([](PyArgs args
   return None;
 });
 
+MATXSCRIPT_REGISTER_GLOBAL("runtime.NDArrayGetImpl").set_body([](PyArgs args) -> RTValue {
+  NDArray data = args[0].As<NDArray>();
+  return static_cast<int64_t>(data.GetImpl());
+});
+
+// TODO: remove this API later. Python shouldn't be able to set impl. For testing purpose only
+MATXSCRIPT_REGISTER_GLOBAL("runtime.NDArraySetImpl").set_body([](PyArgs args) -> RTValue {
+  NDArray data = args[0].As<NDArray>();
+  int64_t flag = args[1].As<int64_t>();
+  data.SetImpl(static_cast<NDArray::Impl>(flag));
+  return None;
+});
+
 }  // namespace runtime
 }  // namespace matxscript

--- a/src/runtime/container/ndarray.cc
+++ b/src/runtime/container/ndarray.cc
@@ -1563,6 +1563,15 @@ NDArray NDArray::as_type(const unicode_view& dtype_str) const {
   return ret;
 }
 
+void NDArray::SetImpl(int64_t impl) {
+  auto container = this->get_mutable();
+  container->impl_ = impl;
+}
+
+int64_t NDArray::GetImpl() const {
+  return this->get_mutable()->impl_;
+}
+
 void NDArray::AssignNDArray(const NDArray& src, NDArray& dst) {
   auto src_container = src.get_mutable();
   auto dst_container = dst.get_mutable();

--- a/src/runtime/container/ndarray.cc
+++ b/src/runtime/container/ndarray.cc
@@ -1563,13 +1563,13 @@ NDArray NDArray::as_type(const unicode_view& dtype_str) const {
   return ret;
 }
 
-void NDArray::SetImpl(int64_t impl) {
+void NDArray::SetImpl(NDArray::Impl impl) {
   auto container = this->get_mutable();
-  container->impl_ = impl;
+  container->impl = impl;
 }
 
-int64_t NDArray::GetImpl() const {
-  return this->get_mutable()->impl_;
+NDArray::Impl NDArray::GetImpl() const {
+  return this->get_mutable()->impl;
 }
 
 void NDArray::AssignNDArray(const NDArray& src, NDArray& dst) {

--- a/test/runtime/test_ndarray_impl.py
+++ b/test/runtime/test_ndarray_impl.py
@@ -1,0 +1,40 @@
+# Copyright 2022 ByteDance Ltd. and/or its affiliates.
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+import numpy as np
+
+import matx
+from matx.runtime.ndarray import NDArrayImpl
+
+
+class TestNDArrayImpl(unittest.TestCase):
+    def test_ndarray_impl(self):
+        a = matx.array.NDArray([1, 2, 3], shape=[3], dtype='int32')
+        self.assertEqual(a._get_impl(), NDArrayImpl.NDARRAY)
+        self.assertTrue(a is a._to_impl())
+        # test numpy implementation
+        a._set_impl(NDArrayImpl.NUMPY)
+        self.assertEqual(a._get_impl(), NDArrayImpl.NUMPY)
+        np.testing.assert_equal(a._to_impl(), a.asnumpy())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This flag allows dynamic type conversion of NDArray to other types at Python level. It is particularly useful to unify the interface when interacting with numpy.ndarray and torch.Tensor without implementing numpy.array or torch.Tensor at matx runtime.