### PR TITLE
[runtime][ffi] fix native object converter

### DIFF
--- a/python/matx/native/_native_object.py
+++ b/python/matx/native/_native_object.py
@@ -105,11 +105,11 @@ def set_class_method(cls):
         setattr(cls, func_name, func)
 
 
-class NativeClass:
+class NativeClass(NativeObject):
     __MATX_NATIVE_OBJECT__ = True
 
     def __init__(self, *args):
-        self.ud_ref = _ffi_api.CreateNativeObject(self.__class__.__name__.encode(), *args)
+        super(NativeClass, self).__init__(self.__class__.__name__, *args)
 
 
 def load_native_object(module):
@@ -120,7 +120,7 @@ def load_native_object(module):
             if inspect.isclass(res) and issubclass(res, NativeClass):
                 continue
             else:
-                raise RuntimeError("{} is aleady registered in matx.native module".format(name))
+                raise RuntimeError("{} is already registered in matx.native module".format(name))
         cls = type(name, (NativeClass, ), {})
         set_class_method(cls)
         setattr(module, name, cls)

--- a/python/matx/pipeline/_register_conveter.py
+++ b/python/matx/pipeline/_register_conveter.py
@@ -30,7 +30,7 @@ def _pipeline_object_converter(value):
         return value.native_op
     if isinstance(value, OpKernel):
         return value.native_op
-    if isinstance(value, (NativeObject)):
+    if isinstance(value, NativeObject):
         return value.ud_ref
     return value
 

--- a/test/runtime/test_native_object.py
+++ b/test/runtime/test_native_object.py
@@ -16,25 +16,26 @@
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-
-from .._ffi._selector import _set_fast_pipeline_object_converter
-from .._ffi._selector import _set_class_symbol
-from .symbol import BaseSymbol
-from ..native import NativeObject
-from .ops import OpKernel
-from .jit_object import JitObject
+import unittest
+import matx
 
 
-def _pipeline_object_converter(value):
-    if isinstance(value, JitObject):
-        return value.native_op
-    if isinstance(value, OpKernel):
-        return value.native_op
-    if isinstance(value, (NativeObject)):
-        return value.ud_ref
-    return value
+class TestRuntimeNativeObject(unittest.TestCase):
+
+    def setUp(self) -> None:
+        pass
+
+    def test_native_object(self):
+        echo_stub = matx.make_native_object("EchoServiceExample", )
+        req = matx.make_native_object("MySimpleNativeDataExample")
+        rsp = matx.make_native_object("MySimpleNativeDataExample")
+        ret = echo_stub.echo(req, rsp)
+        self.assertEqual(rsp.get_content(), b"[Response] hello")
+        return ret
 
 
-_PipelineClasses = (JitObject, OpKernel, NativeObject,)
-_set_fast_pipeline_object_converter(_PipelineClasses, _pipeline_object_converter)
-_set_class_symbol(BaseSymbol)
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
The goal is: the structure registered by c++ can directly interact with python. This is helpful for `C++ Engine` integration