### PR TITLE
[runtime] make DeviceStreamGuard ctor and dtor public

### DIFF
--- a/include/matxscript/runtime/device_api.h
+++ b/include/matxscript/runtime/device_api.h
@@ -216,6 +216,7 @@ class MATX_DLL DeviceAPI {
 };
 
 class DeviceStreamGuard {
+ public:
   DeviceStreamGuard(MATXScriptDevice ctx, std::shared_ptr<void> stream);
   virtual ~DeviceStreamGuard();
 


### PR DESCRIPTION
fix the issue that `DeviceStreamGuard` has protected ctor and dtor. @cloud-mxd please take a look.