### PR TITLE
support iter and reversed of list

### DIFF
--- a/include/matxscript/runtime/container/list_ref.h
+++ b/include/matxscript/runtime/container/list_ref.h
@@ -291,6 +291,9 @@ class List : public ObjectRef {
   static List repeat_one(value_type&& value, int64_t times);
   static List repeat_many(const std::initializer_list<value_type>& values, int64_t times);
 
+  static Iterator builtins_iter(const List& iterable);
+  static Iterator builtins_reversed(const List& iterable);
+
   void clear() const;
 
   value_type pop(int64_t index = -1) const;

--- a/include/matxscript/runtime/generic/generic_funcs.h
+++ b/include/matxscript/runtime/generic/generic_funcs.h
@@ -363,6 +363,10 @@ List kernel_builtins_sorted(const List& iterable, const Any& key_func, bool reve
 List kernel_builtins_sorted(const Tuple& iterable, const Any& key_func, bool reverse);
 RTValue kernel_builtins_sorted(const Any& iterable, const Any& key_func, bool reverse);
 
+// iterator
+Iterator kernel_builtins_iter(const List& iterable);
+Iterator kernel_builtins_reversed(const List& iteratble);
+
 /******************************************************************************
  * python builtin modules and functions
  *

--- a/python/matx/ir/builtin2op.py
+++ b/python/matx/ir/builtin2op.py
@@ -144,6 +144,8 @@ _register_python_builtin("enumerate", "builtins_enumerate")
 _register_python_builtin("zip", "builtins_zip")
 _register_python_builtin("isinstance", "builtins_isinstance")
 _register_python_builtin("sorted", "builtins_sorted")
+_register_python_builtin("iter", "builtins_iter")
+_register_python_builtin("reversed", "builtins_reversed")
 
 ###############################################################################
 # Any object.method

--- a/python/matx/ir/op.py
+++ b/python/matx/ir/op.py
@@ -2528,6 +2528,40 @@ def builtins_sorted(span, iterable, key=None, reverse=False):
         return HLOCast(_type.ListType(), ret, span)
 
 
+def builtins_iter(span, iterable):
+    func_name = 'ir.builtins_iter'
+    iterable_type = iterable.checked_type
+    if _type_rel.is_type_of(iterable, _type.ListType):
+        if iterable_type.is_full_typed():
+            ret = hlo_call_intrin(_type.IteratorType(_type.ObjectType()),
+                                  func_name, span, iterable)
+            return ret
+        else:
+            ret = hlo_call_intrin(_type.IteratorType(_type.ObjectType()), func_name, span, iterable)
+            return ret
+    else:
+        raise NotImplementedError(
+            "iter for {} is not implemented".format(
+                iterable_type.get_py_type_name()))
+
+
+def builtins_reversed(span, iterable):
+    func_name = 'ir.builtins_reversed'
+    iterable_type = iterable.checked_type
+    if _type_rel.is_type_of(iterable, _type.ListType):
+        if iterable_type.is_full_typed():
+            ret = hlo_call_intrin(_type.IteratorType(_type.ObjectType()),
+                                  func_name, span, iterable)
+            return ret
+        else:
+            ret = hlo_call_intrin(_type.IteratorType(_type.ObjectType()), func_name, span, iterable)
+            return ret
+    else:
+        raise NotImplementedError(
+            "reversed for {} is not implemented".format(
+                iterable_type.get_py_type_name()))
+
+
 # random
 def random_random(span):
     func_name = 'ir.random_random'

--- a/src/ir/hlo_builtin_builtins.cc
+++ b/src/ir/hlo_builtin_builtins.cc
@@ -46,6 +46,14 @@ MATXSCRIPT_IR_DEFINE_HLO_BUILTIN_FUNC_GENERIC(builtins, sorted)
     .add_argument("key", "any_view|Any", "")
     .add_argument("reverse", "bool", "");
 
+MATXSCRIPT_IR_DEFINE_HLO_BUILTIN_FUNC_GENERIC(builtins, iter)
+    .set_num_inputs(1)
+    .add_argument("iterable", "List", "");
+
+MATXSCRIPT_IR_DEFINE_HLO_BUILTIN_FUNC_GENERIC(builtins, reversed)
+    .set_num_inputs(1)
+    .add_argument("iterable", "List", "");
+
 MATXSCRIPT_IR_DEFINE_HLO_BUILTIN_FUNC_GENERIC(builtins, unpack)
     .set_num_inputs(1)
     .add_argument("container", "any_view", "");

--- a/src/runtime/container/list_ref.cc
+++ b/src/runtime/container/list_ref.cc
@@ -41,9 +41,12 @@ namespace runtime {
  * Generic List Iterator
  *****************************************************************************/
 
+template <typename ListBiDirectionalIterator>
 class ListIteratorNode : public IteratorNode {
  public:
-  explicit ListIteratorNode(List container, List::iterator iter, List::iterator iter_end)
+  explicit ListIteratorNode(List container,
+                            ListBiDirectionalIterator iter,
+                            ListBiDirectionalIterator iter_end)
       : container_(std::move(container)), first_(iter), last_(iter_end) {
   }
   ~ListIteratorNode() = default;
@@ -74,8 +77,8 @@ class ListIteratorNode : public IteratorNode {
 
  public:
   List container_;
-  List::iterator first_;
-  List::iterator last_;
+  ListBiDirectionalIterator first_;
+  ListBiDirectionalIterator last_;
   friend class IteratorNodeTrait;
 };
 
@@ -552,7 +555,7 @@ void List::sort(const Any& key, bool reverse) const {
 
 // iterators
 Iterator List::iter() const {
-  auto data = make_object<ListIteratorNode>(*this, begin(), end());
+  auto data = make_object<ListIteratorNode<List::iterator>>(*this, begin(), end());
   return Iterator(std::move(data));
 }
 
@@ -654,6 +657,18 @@ List List::Concat<false>(std::initializer_list<List> data) {
     }
   }
   return List{result_node};
+}
+
+Iterator List::builtins_iter(const List& iterable) {
+  auto data =
+      make_object<ListIteratorNode<List::iterator>>(iterable, iterable.begin(), iterable.end());
+  return Iterator(std::move(data));
+}
+
+Iterator List::builtins_reversed(const List& iterable) {
+  auto data = make_object<ListIteratorNode<List::reverse_iterator>>(
+      iterable, iterable.rbegin(), iterable.rend());
+  return Iterator(std::move(data));
 }
 
 template <>

--- a/src/runtime/generic/generic_funcs.cc
+++ b/src/runtime/generic/generic_funcs.cc
@@ -2415,6 +2415,14 @@ RTValue kernel_builtins_sorted(const Any& iterable, const Any& key, bool reverse
   }
 }
 
+Iterator kernel_builtins_iter(const List& iterable) {
+  return List::builtins_iter(iterable);
+}
+
+Iterator kernel_builtins_reversed(const List& iterable) {
+  return List::builtins_reversed(iterable);
+}
+
 /******************************************************************************
  * python builtin modules and functions
  *

--- a/test/script/test_iterator.py
+++ b/test/script/test_iterator.py
@@ -21,6 +21,7 @@ from typing import List, Dict, Set, Tuple
 from typing import Any
 import unittest
 import matx
+import traceback
 
 
 class TestIterator(unittest.TestCase):
@@ -63,6 +64,58 @@ class TestIterator(unittest.TestCase):
 
         matx.script(tuple_iter)(("hello", "hello"))
         matx.script(generic_tuple_iter)(("hello", "hello"))
+
+    def test_list_builtin_iter(self):
+        def builtin_list_iter(li: List) -> List:
+            new_list = []
+            for l in iter(li):
+                new_list.append(l)
+            return new_list
+
+        original_list = [1, 2, 3, 4, 5]
+        python_iter_result = builtin_list_iter(original_list)
+        matx_iter_result = matx.script(builtin_list_iter)(original_list)
+        self.assertListEqual(python_iter_result, list(matx_iter_result))
+
+    def test_list_reversed_iter(self):
+        def builtin_list_reversed(li: List) -> List:
+            new_list = []
+            for l in reversed(li):
+                new_list.append(l)
+            return new_list
+
+        original_list = [1, 2, 3, 4, 5]
+        python_reversed_result = builtin_list_reversed(original_list)
+        matx_reversed_result = matx.script(builtin_list_reversed)(original_list)
+        self.assertListEqual(python_reversed_result, list(matx_reversed_result))
+
+    # tuple's iter is not implemented
+    def test_tuple_iter_exception(self):
+        def builtin_tuple_iter(li: Tuple[int, int]) -> List:
+            new_list = []
+            for l in iter(li):
+                new_list.append(l)
+            return new_list
+
+        original_tuple = (1, 2)
+        try:
+            matx_iter_result = matx.script(builtin_tuple_iter)(original_tuple)
+        except Exception as e:
+            traceback.print_exc()
+
+    # tuple's reversed is not implemented
+    def test_tuple_reversed_exception(self):
+        def builtin_tuple_reversed(li: Tuple[int, int]) -> List:
+            new_list = []
+            for l in reversed(li):
+                new_list.append(l)
+            return new_list
+
+        original_tuple = (1, 2)
+        try:
+            matx_reversed_result = matx.script(builtin_tuple_reversed)(original_tuple)
+        except Exception as e:
+            traceback.print_exc()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- now support iter and reversed for list
- for the type not yet supported, such as tuple, will raise exception and send message as follows:
- Traceback (most recent call last):
  File "test_iterator.py", line 118, in test_tuple_reversed_exception
    matx_reversed_result = matx.script(builtin_tuple_reversed)(original_tuple)
  File "/data00/liliyi.1/matx_dev/matxscript/python/matx/__init__.py", line 352, in script
    return toolchain.script(compiling_obj, *args, **kwargs)
  File "/data00/liliyi.1/matx_dev/matxscript/python/matx/toolchain.py", line 370, in script
    result: context.ScriptContext = from_source(compiling_obj)
  File "/data00/liliyi.1/matx_dev/matxscript/python/matx/script/__init__.py", line 146, in from_source
    raise Exception(str(e)) from None
Exception: File "/data00/liliyi.1/matx_dev/matxscript/test/script/test_iterator.py", line 112, in builtin_tuple_reversed
                for l in reversed(li):
SyntaxError: reversed for Tuple[int64, int64] is not implemented