### PR TITLE
[kernel.mlir] code print enhence

### DIFF
--- a/src/ir/printer/linalg_printer.cc
+++ b/src/ir/printer/linalg_printer.cc
@@ -100,9 +100,9 @@ class LinalgTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   void VisitStmt_(const PrimFuncNode* op, std::ostream& os) override;
   void VisitStmtDefault_(const Object* op, std::ostream& os) override;
 
-  void VisitStmt_(const BufferStoreNode* op, std::ostream &os) override;
-  void VisitStmt_(const ComputeBlockNode* op, std::ostream &os) override;
-  void VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream &os) override;
+  void VisitStmt_(const BufferStoreNode* op, std::ostream& os) override;
+  void VisitStmt_(const ComputeBlockNode* op, std::ostream& os) override;
+  void VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream& os) override;
 
   template <typename T>
   void GenLinalgArithStatement(const std::string& arith_type,
@@ -115,7 +115,7 @@ class LinalgTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
 
   std::pair<std::string, std::string> GetNodeDataType(const PrimExprNode* op);
 
-  void ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream &os);
+  void ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream& os);
   void LibraryNodeToLinalgGeneric();
 
   // Begin Type
@@ -339,7 +339,9 @@ void LinalgTextPrinter::VisitStmt_(const ReturnStmtNode* op, std::ostream& os) {
     auto node = runtime::Downcast<PrimExpr>(op->value);
     PrimExprFunctor::VisitExpr(node, os);
     os << "func.return %" << GetNodeName(op->value);
-    os << " :" << ConvertTypeToMLIR(node->checked_type()) << std::endl;
+    os << " :";
+    VisitType(node->checked_type(), os);
+    os << std::endl;
   } else {
     MXCHECK(false) << "[linalg] not support expr node: " << op->value;
   }
@@ -369,7 +371,8 @@ void LinalgTextPrinter::VisitStmt_(const PrimFuncNode* op, std::ostream& os) {
     auto& param = func_params[i];
     if (param->IsInstance<PrimVarNode>()) {
       auto node = runtime::Downcast<PrimVar>(param);
-      os << "%" << node->name_hint << ": " << ConvertTypeToMLIR(node->checked_type());
+      os << "%" << node->name_hint << ": ";
+      VisitType(node->checked_type(), os);
     } else {
       MXCHECK(false) << "[linalg] not support arg node: " << param->checked_type();
     }
@@ -380,7 +383,8 @@ void LinalgTextPrinter::VisitStmt_(const PrimFuncNode* op, std::ostream& os) {
   os << ")";
   auto rt_type = op->GetReturnType();
   if (!IsVoidType(rt_type)) {
-    os << "->" << ConvertTypeToMLIR(rt_type);
+    os << "->";
+    VisitType(rt_type, os);
   }
   // check if none
   // if so skip
@@ -390,28 +394,30 @@ void LinalgTextPrinter::VisitStmt_(const PrimFuncNode* op, std::ostream& os) {
   os << "}" << std::endl;
 }
 
-void LinalgTextPrinter::VisitStmt_(const BufferStoreNode* op, std::ostream &os){
-
+void LinalgTextPrinter::VisitStmt_(const BufferStoreNode* op, std::ostream& os) {
 }
-void LinalgTextPrinter::VisitStmt_(const ComputeBlockNode* op, std::ostream &os){
-
+void LinalgTextPrinter::VisitStmt_(const ComputeBlockNode* op, std::ostream& os) {
 }
-void LinalgTextPrinter::VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream &os){
-
+void LinalgTextPrinter::VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream& os) {
 }
 
-void LinalgTextPrinter::ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream &os){}
-void LinalgTextPrinter::LibraryNodeToLinalgGeneric(){}
-
+void LinalgTextPrinter::ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream& os) {
+}
+void LinalgTextPrinter::LibraryNodeToLinalgGeneric() {
+}
 
 // Begin Type
 void LinalgTextPrinter::VisitType_(const PrimTypeNode* node, std::ostream& os) {
+  os << ConvertTypeToMLIR(node->dtype);
 }
 
 void LinalgTextPrinter::VisitType_(const PointerTypeNode* node, std::ostream& os) {
+  auto dtype = ConvertTypeToMLIR(node->element_type);
+  os << "memref<?x" + dtype + ">";
 }
 
 void LinalgTextPrinter::VisitType_(const NDArrayTypeNode* node, std::ostream& os) {
+  VisitTypeDefault_(node, os);
 }
 
 // Global Linalg TextPrint

--- a/src/ir/printer/linalg_printer.cc
+++ b/src/ir/printer/linalg_printer.cc
@@ -100,9 +100,9 @@ class LinalgTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   void VisitStmt_(const PrimFuncNode* op, std::ostream& os) override;
   void VisitStmtDefault_(const Object* op, std::ostream& os) override;
 
-  // void VisitStmt_(const BufferStoreNode* op, std::ostream &os) override;
-  // void VisitStmt_(const ComputeBlockNode* op, std::ostream &os) override;
-  // void VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream &os) override;
+  void VisitStmt_(const BufferStoreNode* op, std::ostream &os) override;
+  void VisitStmt_(const ComputeBlockNode* op, std::ostream &os) override;
+  void VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream &os) override;
 
   template <typename T>
   void GenLinalgArithStatement(const std::string& arith_type,
@@ -114,6 +114,9 @@ class LinalgTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   std::string GetNodeName(const BaseExpr& ptr);
 
   std::pair<std::string, std::string> GetNodeDataType(const PrimExprNode* op);
+
+  void ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream &os);
+  void LibraryNodeToLinalgGeneric();
 
   // Begin Type
   // Overload of Type printing functions
@@ -386,6 +389,20 @@ void LinalgTextPrinter::VisitStmt_(const PrimFuncNode* op, std::ostream& os) {
   VisitStmt(op->body, os);
   os << "}" << std::endl;
 }
+
+void LinalgTextPrinter::VisitStmt_(const BufferStoreNode* op, std::ostream &os){
+
+}
+void LinalgTextPrinter::VisitStmt_(const ComputeBlockNode* op, std::ostream &os){
+
+}
+void LinalgTextPrinter::VisitStmt_(const ComputeBlockRealizeNode* op, std::ostream &os){
+
+}
+
+void LinalgTextPrinter::ComputeBlockToLinalgGeneric(const ComputeBlockNode* op, std::ostream &os){}
+void LinalgTextPrinter::LibraryNodeToLinalgGeneric(){}
+
 
 // Begin Type
 void LinalgTextPrinter::VisitType_(const PrimTypeNode* node, std::ostream& os) {

--- a/test/kernel/test_linalg_printer.py
+++ b/test/kernel/test_linalg_printer.py
@@ -40,6 +40,7 @@ class TestLinalgStatementPrint(unittest.TestCase):
         func_name = "test_float_arith_op"
         prim_func = prim_func.with_attr("global_symbol", func_name)
         linalg_statement = _ffi_node_api.as_linalg_text(prim_func).decode()
+        print(linalg_statement)
         expected_statement = """
 func.func @test_float_arith_op(%a: f32, %b: f32, %c: f32, %d: f32, %e: f32)->f32{
 %0 = arith.addf %a, %b : f32
@@ -66,6 +67,7 @@ func.return %3 :f32
         func_name = "test_int_arith_op"
         prim_func = prim_func.with_attr("global_symbol", func_name)
         linalg_statement = _ffi_node_api.as_linalg_text(prim_func).decode()
+        print(linalg_statement)
         expected_statement = """
 func.func @test_int_arith_op(%a: i32, %b: i32, %c: i32, %d: i32, %e: i32)->i32{
 %0 = arith.addi %a, %b : i32
@@ -85,6 +87,7 @@ func.return %3 :i32
         func_name = "test_pointer_op_memref_i32"
         prim_func = prim_func.with_attr("global_symbol", func_name)
         linalg_statement = _ffi_node_api.as_linalg_text(prim_func).decode()
+        print(linalg_statement)
         expected_statement = """
 func.func @test_pointer_op_memref_i32(%a: memref<?xi32>)->memref<?xi32>{
 func.return %a :memref<?xi32>
@@ -100,6 +103,7 @@ func.return %a :memref<?xi32>
         func_name = "basic_arith_op"
         prim_func = prim_func.with_attr("global_symbol", func_name)
         linalg_statement = _ffi_node_api.as_linalg_text(prim_func).decode()
+        print(linalg_statement)
         expected_statement = """
 func.func @basic_arith_op(%a: memref<?xf64>)->memref<?xf64>{
 func.return %a :memref<?xf64>


### PR DESCRIPTION
1. Add functions for visiting BufferStoreNode, ComputeBlockNode, and ComputeBlockRealizeNode.
2. rename expr_index_map_ to expr_name_map_ and made it store both user defined variables and tmp variables.
3. rename GetNodeName to PrintNodeName for printing both user defined variables and tmp variables.
4. replace MXCHECK(false) and MXLOG(FATAL) by MXTHROW.
5. fill functions for ForNode, AssertStmtNode, and SeqStmtNode.
6. fill functions for visiting type (VisitType)
7. add print(linalg_statement) in test for visual checks.