### PR TITLE
[Kernel] update benchmark

### DIFF
--- a/python/matx/kernel/compile_linalg.py
+++ b/python/matx/kernel/compile_linalg.py
@@ -97,6 +97,8 @@ def lower_linalg_to_cpu(input_fname, output_fname="llvm_tmp.mlir"):
                               '--convert-arith-to-llvm',
                               '--convert-memref-to-llvm',
                               '--convert-cf-to-llvm',
+                              '--scf-for-loop-peeling',
+                              '--scf-for-loop-specialization',
                               '--reconcile-unrealized-casts',
                               input_fname,
                               '-o',
@@ -133,6 +135,7 @@ def translate_to_llvm(input_fname, output_fname="llvm_tmp.ll"):
 def llvm_compile(input_fname, output_fname="llvm_tmp.ll"):
     env = os.environ.copy()
     compile_llvm = subprocess.Popen(["llc",
+                                     "-O3",
                                      "-filetype=obj",
                                      input_fname,
                                      "-o",

--- a/test/kernel/single_return_benchmark.py
+++ b/test/kernel/single_return_benchmark.py
@@ -16,8 +16,10 @@
 #  KIND, either express or implied.  See the License for the
 #  specific language governing permissions and limitations
 #  under the License.
-
-import unittest
+import os
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["NUMEXPR_NUM_THREADS"] = "1"
+os.environ["OMP_NUM_THREADS"] = "1"
 import numpy as np
 import sympy
 import time
@@ -25,44 +27,48 @@ from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
 from matx.kernel.typing import int32, int64, float32
 
-WARM_UP = 100
-ITERATION = 30000
+WARM_UP = 10000
+ITERATION = 60000
 
 
-class TestSingleReturnParser(unittest.TestCase):
+def benchmark():
+    M = sympy.Symbol('M', positive=True)
+    N = sympy.Symbol('N', positive=True)
 
-    def test_multiple_bin_op_with_scalar_and_const(self):
-        M = sympy.Symbol('M', positive=True)
-        N = sympy.Symbol('N', positive=True)
+    def foo(a: int32[M, N], b: int64[M, N], c: float32) -> float32[M, N]:
+        return ((a + b) * c) + 1 + a
 
-        def foo(a: int32[M, N], b: int64[M, N], c: float32) -> float32[M, N]:
-            return ((a + b) * c) + 1 + a
+    p = KernelParser(foo)
+    p.parse()
 
-        p = KernelParser(foo)
-        p.parse()
+    a = np.arange(300 * 400, dtype=np.int32).reshape(300, 400)
+    b = np.arange(300 * 400, dtype=np.int64).reshape(300, 400)
+    c = np.float32(3)
+    rt = np.zeros(a.shape, dtype=np.float32)
+    f = compile_linalg(p)
+    c_args, _ = f.to_c_args(a, b, c, rt=rt)
+    print('-' * 100)
+    print(*c_args)
 
-        a = np.arange(300 * 400, dtype=np.int32).reshape(300, 400)
-        b = np.arange(300 * 400, dtype=np.int64).reshape(300, 400)
-        c = np.float32(3)
-        rt = np.zeros(a.shape, dtype=np.float32)
-        f = compile_linalg(p)
-        c_args, _ = f.to_c_args(a, b, c, rt=rt)
-        print('-' * 100)
-        print(*c_args)
+    # warmup
+    for _ in range(WARM_UP):
+        _ = np.zeros(a.shape, dtype=np.float32)
+        f.raw_call(*c_args)
 
-        # warmup
-        for _ in range(WARM_UP):
-            f.raw_call(*c_args)
+    linalg_start_time = time.time()
+    for _ in range(ITERATION):
+        _ = np.zeros(a.shape, dtype=np.float32)
+        f.raw_call(*c_args)
+    print("--- linalg time: %s seconds ---" % (time.time() - linalg_start_time))
 
-        linalg_start_time = time.time()
-        for _ in range(ITERATION):
-            f.raw_call(*c_args)
-        print("--- linalg time: %s seconds ---" % (time.time() - linalg_start_time))
+    for _ in range(WARM_UP):
+        _ = foo(a, b, c)
 
-        for _ in range(WARM_UP):
-            _ = foo(a, b, c)
+    numpy_start_time = time.time()
+    for _ in range(ITERATION):
+        _ = foo(a, b, c)
+    print("--- numpy time: %s seconds ---" % (time.time() - numpy_start_time))
 
-        numpy_start_time = time.time()
-        for _ in range(ITERATION):
-            _ = foo(a, b, c)
-        print("--- numpy time: %s seconds ---" % (time.time() - numpy_start_time))
+
+if __name__ == '__main__':
+    benchmark()


### PR DESCRIPTION
1. Enabled o3 and other optimization in the benchmark.
2. In the kernel benchmark, the creation of an ndarray was intentionally incorporated to serve as a minor overhead, aligning the kernel benchmark with the code used for the numpy benchmark.
3. Removed the use of the unit test framework in the benchmark code.
