### PR TITLE
[kernel]enhance the MLIR codegen printer (Part 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ build
 !/vision/README.md
 
 # for kernel
-/test/kernel/*.o
-/test/kernel/*.mlir
-/test/kernel/*.so
-/test/kernel/*.ll
+/test/kernel/**/*.o
+/test/kernel/**/*.mlir
+/test/kernel/**/*.so
+/test/kernel/**/*.ll

--- a/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
+++ b/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
@@ -122,7 +122,13 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   template <typename T>
   void GenMLIRArithStatement(const std::string& arith_type,
                              const PrimBinaryOpNode<T>* op,
-                             std::ostream& os);
+                             std::ostream& os,
+                             const std::unordered_map<std::string, std::string>& suffix_map = {});
+
+  template <typename T>
+  void GenMLIRCompareStatement(const std::string& compare_type,
+                               const PrimCmpOpNode<T>* op,
+                               std::ostream& os);
 
   std::string ConvertTypeToMLIR(const runtime::DataType& type) const;
   std::string ConvertTypeToMLIR(const Type& type) const;

--- a/python/matx/kernel/compile_linalg.py
+++ b/python/matx/kernel/compile_linalg.py
@@ -104,6 +104,7 @@ def lower_linalg_to_cpu(input_fname, output_fname="llvm_tmp.mlir"):
                               '--convert-index-to-llvm',
                               '--convert-arith-to-llvm',
                               '--convert-memref-to-llvm',
+                              '--convert-math-to-llvm',
                               '--convert-cf-to-llvm',
                               '--scf-for-loop-peeling',
                               '--scf-for-loop-specialization',

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -95,3 +95,25 @@ class BinaryOp(ExpressionBaseNode):
 
     def buffer_regions(self, **kwargs):
         return self.lhs.buffer_regions(**kwargs) + self.rhs.buffer_regions(**kwargs)
+
+
+class UnaryOp(ExpressionBaseNode):
+
+    def __init__(self, operand: ExpressionBaseNode, op_type, span):
+        self.op = _unaryop_maker[op_type]
+        self.operand = operand
+        self.span = span
+        self.operand_type = operand.kernel_type
+        self.operand_dtype = get_dtype(self.operand_type)
+        self.result_dtype = np_result_dtype([self.operand_dtype])
+        result_shape = self.operand.kernel_type.shape
+        self.result_shape = tuple(result_shape)
+        self.result_type = NDArrayType(self.result_shape, self.result_dtype)
+        super().__init__(self.result_type)
+        self.shape = result_shape
+
+    def to_matx_ir(self, **kwargs):
+        return self.op(self.operand.to_matx_ir(**kwargs), self.span)
+
+    def buffer_regions(self, **kwargs):
+        return self.operand.buffer_regions(**kwargs)

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -29,7 +29,9 @@ _arithmetic_binop_maker = {
     ast.Mult: lambda lhs, rhs, span: _generic.multiply(lhs, rhs, span),
     ast.Div: lambda lhs, rhs, span: _generic.divide(lhs, rhs, span),
     ast.FloorDiv: lambda lhs, rhs, span: _generic.floordiv(lhs, rhs, span),
-    ast.Mod: lambda lhs, rhs, span: _generic.floormod(lhs, rhs, span),
+    # ast.Mod: lambda lhs, rhs, span: _generic.floormod(lhs, rhs, span),
+    # quick fix for mod sign issue
+    ast.Mod: lambda lhs, rhs, span: _generic.floormod(_generic.add(_generic.floormod(lhs, rhs, span), rhs, span), rhs, span),
     ast.BitOr: lambda lhs, rhs, span: _generic.bitwise_or(lhs, rhs, span),
     ast.BitAnd: lambda lhs, rhs, span: _generic.bitwise_and(lhs, rhs, span),
     ast.BitXor: lambda lhs, rhs, span: _generic.bitwise_xor(lhs, rhs, span),

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -77,7 +77,7 @@ class BinaryOp(ExpressionBaseNode):
         self.lhs_shape = get_shape(self.lhs_type)
         self.rhs_shape = get_shape(self.rhs_type)
         if self.is_boolean_op:
-            self.result_dtype = bool_
+            self.result_dtype = np.bool_
         else:
             self.result_dtype = np_result_dtype([self.lhs_dtype, self.rhs_dtype])
         result_shape, lhs_new_shape, rhs_new_shape = broadcast(self.lhs_shape, self.rhs_shape)

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -56,8 +56,8 @@ _boolop_marker = {
     ast.IsNot: lambda lhs, rhs, span: _generic.op_not(_generic.op_is(lhs, rhs, span), span),
 
 
-    ast.And: lambda span, *args: _generic.op_and(span, *args),
-    ast.Or: lambda span, *args: _generic.op_or(span, *args)
+    ast.And: lambda lhs, rhs, span: _generic.op_and(span, lhs, rhs),
+    ast.Or: lambda lhs, rhs, span: _generic.op_or(span, lhs, rhs)
 }
 
 

--- a/python/matx/kernel/parser/base_parser.py
+++ b/python/matx/kernel/parser/base_parser.py
@@ -102,7 +102,13 @@ class BaseParser(ast.NodeVisitor):
 
     # Expressions
     def visit_UnaryOp(self, node: ast.UnaryOp) -> Any:
-        raise NotImplementedError("visit_UnaryOp is not Implemented")
+        opname = type(node.op).__name__
+        operand_ir = self.visit(node.operand)
+        if (is_scalar_type(operand_ir.kernel_type) or is_symbol_type(operand_ir.kernel_type)):
+            return UnaryOp(operand_ir, type(node.op), self.build_span(node))
+        else:
+            raise SyntaxError(f"{opname} ({operand_ir}) is not supported "
+                              f"because {operand_ir} is not a scalar")
 
     def visit_BinOp(self, node: ast.BinOp) -> Any:
         opname = type(node.op).__name__

--- a/python/matx/kernel/parser/base_parser.py
+++ b/python/matx/kernel/parser/base_parser.py
@@ -311,7 +311,18 @@ class BaseParser(ast.NodeVisitor):
         return [*value, attr_name]
 
     def visit_Return(self, node: ast.Return) -> Any:
-        pass
+        if node.value is None:
+            return _ir.ReturnStmt(NoneExpr())
+        if not is_scalar_type(self.return_ctx.kernel_type):
+            raise NotImplementedError(
+                "base parser does not support returning things other than scalar")
+
+        rt_ir = self.visit(node.value)
+        if not is_scalar_shape(rt_ir.shape):
+            raise NotImplementedError(
+                "The return value is not a scalar which does not match the annotation")
+
+        return _ir.ReturnStmt(rt_ir.to_matx_ir())
 
     def visit_Tuple(self, node: ast.Tuple) -> Any:
         values = []

--- a/python/matx/kernel/typing/__init__.py
+++ b/python/matx/kernel/typing/__init__.py
@@ -17,7 +17,7 @@
 #   * specific language governing permissions and limitations
 #   * under the License.
 #   */
-
+import numpy as np
 
 from .broadcast import *
 from .kernel_type import *
@@ -35,13 +35,13 @@ uint64: ScalarType = ScalarType(np.uint64)
 # float16: ScalarType = ScalarType(np.float16)
 float32: ScalarType = ScalarType(np.float32)
 float64: ScalarType = ScalarType(np.float64)
-bool_ = None  # todo implement bool
+boolean: ScalarType = ScalarType(np.bool_)  # todo implement bool
 
 PYTYPE_TO_KERNEL_TYPE = {
     bool: ScalarType(bool),
     int: ScalarType(int),
     float: ScalarType(float),
-    np.bool_: bool_,
+    np.bool_: boolean,
     np.int8: int8,
     np.int16: int16,
     np.int32: int32,

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -470,6 +470,9 @@ void printCastOp(const Type& origin, const Type& target, std::ostream& os) {
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimCastNode* op, std::ostream& os) {
+  if (expr_name_map_->find(op) != expr_name_map_->end()) {
+    return;
+  }
   auto& v = op->value;
   PrimExprFunctor::VisitExpr(v, os);
   os << '%' << cur_index_ << " = ";
@@ -478,9 +481,6 @@ void MLIRTextPrinter::VisitExpr_(const PrimCastNode* op, std::ostream& os) {
   os << " : ";
   os << ConvertTypeToMLIR(v->checked_type()) << " to " << ConvertTypeToMLIR(op->checked_type())
      << std::endl;
-  if (expr_name_map_->find(op) != expr_name_map_->end()) {
-    MXTHROW << "[linalg] op is already in expr_index_map_";
-  }
   insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -384,9 +384,53 @@ void MLIRTextPrinter::VisitExpr_(const PrimGENode* op, std::ostream& os) {
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimAndNode* op, std::ostream& os) {
+  PrimExprFunctor::VisitExpr(op->a, os);
+  PrimExprFunctor::VisitExpr(op->b, os);
+  const auto& a_type = GetNodeDataType(op->a.get());
+  const auto& b_type = GetNodeDataType(op->b.get());
+  const auto& rc_type = GetNodeDataType(op);
+  MXCHECK_EQ(a_type.second, b_type.second)
+      << "[mlir printer] the two values for comparesion are not the same type";
+  MXCHECK_EQ(a_type.first, b_type.first)
+      << "[mlir printer] the two values for comparesion are not the same type";
+  const auto& a_arith_suffix = a_type.second;
+  const std::string op_name = "arith.andi ";
+
+  os << '%' << cur_index_ << " = " << op_name;
+  PrintNodeName(op->a, os);
+  os << ", ";
+  PrintNodeName(op->b, os);
+  os << " : " << rc_type.first << std::endl;
+  if (expr_name_map_->find(op) != expr_name_map_->end()) {
+    MXTHROW << "[linalg] op is already in expr_index_map_";
+  }
+  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  cur_index_ += 1;
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimOrNode* op, std::ostream& os) {
+  PrimExprFunctor::VisitExpr(op->a, os);
+  PrimExprFunctor::VisitExpr(op->b, os);
+  const auto& a_type = GetNodeDataType(op->a.get());
+  const auto& b_type = GetNodeDataType(op->b.get());
+  const auto& rc_type = GetNodeDataType(op);
+  MXCHECK_EQ(a_type.second, b_type.second)
+      << "[mlir printer] the two values for comparesion are not the same type";
+  MXCHECK_EQ(a_type.first, b_type.first)
+      << "[mlir printer] the two values for comparesion are not the same type";
+  const auto& a_arith_suffix = a_type.second;
+  const std::string op_name = "arith.ori ";
+
+  os << '%' << cur_index_ << " = " << op_name;
+  PrintNodeName(op->a, os);
+  os << ", ";
+  PrintNodeName(op->b, os);
+  os << " : " << rc_type.first << std::endl;
+  if (expr_name_map_->find(op) != expr_name_map_->end()) {
+    MXTHROW << "[linalg] op is already in expr_index_map_";
+  }
+  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  cur_index_ += 1;
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimNotNode* op, std::ostream& os) {

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -278,12 +278,12 @@ void MLIRTextPrinter::VisitExpr_(const PrimModNode* op, std::ostream& os) {
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimFloorDivNode* op, std::ostream& os) {
-  std::unordered_map<std::string, std::string> suffix_map = {{"i", "si"}};
-  GenMLIRArithStatement("floordiv", op, os, suffix_map);
+  GenMLIRArithStatement("div", op, os);
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimFloorModNode* op, std::ostream& os) {
-  VisitExprDefault_(op, os);
+  std::unordered_map<std::string, std::string> suffix_map = {{"i", "si"}};
+  GenMLIRArithStatement("rem", op, os, suffix_map);
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimMinNode* op, std::ostream& os) {

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -418,7 +418,6 @@ void MLIRTextPrinter::VisitExpr_(const PrimOrNode* op, std::ostream& os) {
       << "[mlir printer] the two values for comparesion are not the same type";
   MXCHECK_EQ(a_type.first, b_type.first)
       << "[mlir printer] the two values for comparesion are not the same type";
-  const auto& a_arith_suffix = a_type.second;
   const std::string op_name = "arith.ori ";
 
   os << '%' << cur_index_ << " = " << op_name;
@@ -434,6 +433,22 @@ void MLIRTextPrinter::VisitExpr_(const PrimOrNode* op, std::ostream& os) {
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimNotNode* op, std::ostream& os) {
+  PrimExprFunctor::VisitExpr(op->a, os);
+  const auto& a_type = GetNodeDataType(op->a.get());
+  MXCHECK_EQ(a_type.second, "i") << "[mlir printer] the operand for not op should only be a int";
+  const auto& rc_type = GetNodeDataType(op);
+  const std::string op_name = "arith.xori ";
+  const std::string const1 = '%' + std::to_string(cur_index_);
+  cur_index_++;
+  os << const1 << " = arith.constant 1 : " << a_type.first << std::endl;
+  os << '%' << cur_index_ << " = " << op_name << const1 << ", ";
+  PrintNodeName(op->a, os);
+  os << " : " << rc_type.first << std::endl;
+  if (expr_name_map_->find(op) != expr_name_map_->end()) {
+    MXTHROW << "[linalg] op is already in expr_index_map_";
+  }
+  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  cur_index_ += 1;
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimSelectNode* op, std::ostream& os) {

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -44,13 +44,13 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
 
         foo = self.helper(foo)
 
-        self.assertEqual(foo(0, 1), 1)
-        self.assertEqual(foo(-1, 1), 0)
-        self.assertEqual(foo(-5, -8), -13)
-        self.assertEqual(foo(5, 7), 12)
+        self.assertEqual(1, foo(0, 1))
+        self.assertEqual(0, foo(-1, 1))
+        self.assertEqual(-13, foo(-5, -8))
+        self.assertEqual(12, foo(5, 7))
         # overflow case
-        self.assertEqual(foo(2147483647, 1), -2147483648)
-        self.assertEqual(foo(-2147483648, -1), 2147483647)
+        self.assertEqual(-2147483648, foo(2147483647, 1))
+        self.assertEqual(2147483647, foo(-2147483648, -1))
 
     def test_int_sub(self):
         def foo(a: int32, b: int32) -> int32:
@@ -58,22 +58,22 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
 
         foo = self.helper(foo)
 
-        self.assertEqual(foo(0, 1), -1)
-        self.assertEqual(foo(-1, 1), -2)
-        self.assertEqual(foo(1, 1), 0)
-        self.assertEqual(foo(-5, -8), 3)
-        self.assertEqual(foo(5, 7), -2)
+        self.assertEqual(-1, foo(0, 1))
+        self.assertEqual(-2, foo(-1, 1))
+        self.assertEqual(0, foo(1, 1))
+        self.assertEqual(3, foo(-5, -8))
+        self.assertEqual(-2, foo(5, 7))
 
     def test_int_mul(self):
         def foo(a: int32, b: int32) -> int32:
             return a * b
 
         foo = self.helper(foo)
-        self.assertEqual(foo(0, 1), 0)
-        self.assertEqual(foo(-1, 1), -1)
-        self.assertEqual(foo(1, 1), 1)
-        self.assertEqual(foo(-5, -8), 40)
-        self.assertEqual(foo(5, 7), 35)
+        self.assertEqual(0, foo(0, 1))
+        self.assertEqual(-1, foo(-1, 1))
+        self.assertEqual(1, foo(1, 1))
+        self.assertEqual(40, foo(-5, -8))
+        self.assertEqual(35, foo(5, 7))
 
     def test_int_div(self):
         # numpy int32/int32 = float 64
@@ -81,42 +81,42 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
             return a / b
 
         foo = self.helper(foo)
-        self.assertEqual(foo(0, 1), 0 / 1)
-        self.assertEqual(foo(-1, 1), -1 / 1)
-        self.assertEqual(foo(1, 1), 1 / 1)
-        self.assertEqual(foo(-5, -8), -5 / -8)
-        self.assertEqual(foo(5, 7), 5 / 7)
+        self.assertEqual(0 / 1, foo(0, 1))
+        self.assertEqual(-1 / 1, foo(-1, 1))
+        self.assertEqual(1 / 1, foo(1, 1))
+        self.assertEqual(-5 / -8, foo(-5, -8))
+        self.assertEqual(5 / 7, foo(5, 7))
 
     def test_int_rem(self):
         def foo(a: int32, b: int32) -> int32:
             return a % b
 
         foo = self.helper(foo)
-        self.assertEqual(foo(-10, 3), -10 % 3)
-        self.assertEqual(foo(0, 1), 0 % 1)
-        self.assertEqual(foo(-1, 1), -1 % 1)
-        self.assertEqual(foo(1, 1), 1 % 1)
-        self.assertEqual(foo(-5, -8), -5 % -8)
-        self.assertEqual(foo(5, -8), 5 % -8)
-        self.assertEqual(foo(5, 7), 5 % 7)
-        self.assertEqual(foo(-5, 7), -5 % 7)
-        self.assertEqual(foo(18328, 32202), 18328 % 32202)
-        self.assertEqual(foo(32202, 18328), 32202 % 18328)
-        self.assertEqual(foo(-18328, 32202), -18328 % 32202)
-        self.assertEqual(foo(18328, -32202), 18328 % -32202)
+        self.assertEqual(-10 % 3, foo(-10, 3))
+        self.assertEqual(0 % 1, foo(0, 1))
+        self.assertEqual(-1 % 1, foo(-1, 1))
+        self.assertEqual(1 % 1, foo(1, 1))
+        self.assertEqual(-5 % -8, foo(-5, -8))
+        self.assertEqual(5 % -8, foo(5, -8))
+        self.assertEqual(5 % 7, foo(5, 7))
+        self.assertEqual(-5 % 7, foo(-5, 7))
+        self.assertEqual(18328 % 32202, foo(18328, 32202))
+        self.assertEqual(32202 % 18328, foo(32202, 18328))
+        self.assertEqual(-18328 % 32202, foo(-18328, 32202))
+        self.assertEqual(18328 % -32202, foo(18328, -32202))
 
     def test_int_floordiv(self):
         def foo(a: int32, b: int32) -> int32:
             return a // b
 
         foo = self.helper(foo)
-        self.assertEqual(foo(0, 1), 0 // 1)
-        self.assertEqual(foo(-1, 1), -1 // 1)
-        self.assertEqual(foo(1, 1), 1 // 1)
-        self.assertEqual(foo(-5, -8), -5 // -8)
-        self.assertEqual(foo(5, 7), 5 // 7)
-        self.assertEqual(foo(5, -2), -3)
-        self.assertEqual(foo(5, 2), 2)
+        self.assertEqual(0 // 1, foo(0, 1))
+        self.assertEqual(-1 // 1, foo(-1, 1))
+        self.assertEqual(1 // 1, foo(1, 1))
+        self.assertEqual(-5 // -8, foo(-5, -8))
+        self.assertEqual(5 // 7, foo(5, 7))
+        self.assertEqual(-3, foo(5, -2))
+        self.assertEqual(2, foo(5, 2))
 
     def test_int_min(self):
         def foo(a: int32, b: int32) -> int32:
@@ -151,12 +151,12 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
 
         foo = self.helper(foo)
 
-        self.assertAlmostEquals(foo(0, 1.213), 1.213)
-        self.assertAlmostEquals(foo(0, 1.213), 1.213)
-        self.assertAlmostEquals(foo(0.1, 1.213), 1.313)
-        self.assertAlmostEquals(foo(-1.1, 1.1), 0)
-        self.assertAlmostEquals(foo(-5.9, -8.0001), -13.9001)
-        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 + 7.287953)
+        self.assertAlmostEquals(1.213, foo(0, 1.213))
+        self.assertAlmostEquals(1.213, foo(0, 1.213))
+        self.assertAlmostEquals(1.313, foo(0.1, 1.213))
+        self.assertAlmostEquals(0, foo(-1.1, 1.1))
+        self.assertAlmostEquals(-13.9001, foo(-5.9, -8.0001))
+        self.assertAlmostEquals(5.34 + 7.287953, foo(5.34, 7.287953))
 
     def test_float_sub(self):
         def foo(a: float64, b: float64) -> float64:
@@ -164,24 +164,24 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
 
         foo = self.helper(foo)
 
-        self.assertAlmostEquals(foo(0, 1.213), -1.213)
-        self.assertAlmostEquals(foo(0, 1.213), -1.213)
-        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 - 1.213)
-        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 - 1.1)
-        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 - (-8.0001))
-        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 - 7.287953)
+        self.assertAlmostEquals(-1.213, foo(0, 1.213))
+        self.assertAlmostEquals(-1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0.1 - 1.213, foo(0.1, 1.213))
+        self.assertAlmostEquals(-1.1 - 1.1, foo(-1.1, 1.1))
+        self.assertAlmostEquals(-5.9 - (-8.0001), foo(-5.9, -8.0001))
+        self.assertAlmostEquals(5.34 - 7.287953, foo(5.34, 7.287953))
 
     def test_float_mul(self):
         def foo(a: float64, b: float64) -> float64:
             return a * b
 
         foo = self.helper(foo)
-        self.assertAlmostEquals(foo(0, 1.213), 0 * 1.213)
-        self.assertAlmostEquals(foo(0, 1.213), 0 * 1.213)
-        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 * 1.213)
-        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 * 1.1)
-        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 * (-8.0001))
-        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 * 7.287953)
+        self.assertAlmostEquals(0 * 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0 * 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0.1 * 1.213, foo(0.1, 1.213))
+        self.assertAlmostEquals(-1.1 * 1.1, foo(-1.1, 1.1))
+        self.assertAlmostEquals(-5.9 * (-8.0001), foo(-5.9, -8.0001))
+        self.assertAlmostEquals(5.34 * 7.287953, foo(5.34, 7.287953))
 
     def test_float_div(self):
         # numpy int32/int32 = float 64
@@ -189,34 +189,34 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
             return a / b
 
         foo = self.helper(foo)
-        self.assertAlmostEquals(foo(0, 1.213), 0 / 1.213)
-        self.assertAlmostEquals(foo(0, 1.213), 0 / 1.213)
-        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 / 1.213)
-        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 / 1.1)
-        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 / (-8.0001))
-        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 / 7.287953)
+        self.assertAlmostEquals(0 / 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0 / 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0.1 / 1.213, foo(0.1, 1.213))
+        self.assertAlmostEquals(-1.1 / 1.1, foo(-1.1, 1.1))
+        self.assertAlmostEquals(-5.9 / (-8.0001), foo(-5.9, -8.0001))
+        self.assertAlmostEquals(5.34 / 7.287953, foo(5.34, 7.287953))
 
     def test_float_rem(self):
         def foo(a: float64, b: float64) -> float64:
             return a % b
 
         foo = self.helper(foo)
-        self.assertEqual(foo(10, -3), 10 % -3)
-        self.assertEqual(foo(-10, 3), -10 % 3)
-        self.assertEqual(foo(0, 1.1), 0 % 1.1)
-        self.assertEqual(foo(-1.1, 1.2), -1.1 % 1.2)
-        self.assertEqual(foo(1, 1), 1 % 1)
-        self.assertEqual(foo(-5, -8), -5 % -8)
-        self.assertEqual(foo(5, -8), 5 % -8)
-        self.assertEqual(foo(5.5, -8.3), 5.5 % -8.3)
-        self.assertEqual(foo(5, 7), 5 % 7)
-        self.assertEqual(foo(-5, 7), -5 % 7)
-        self.assertEqual(foo(-5.34, 7.68), -5.34 % 7.68)
-        self.assertEqual(foo(18328, 32202), 18328 % 32202)
-        self.assertEqual(foo(32202, 18328), 32202 % 18328)
-        self.assertEqual(foo(-18328, 32202), -18328 % 32202)
-        self.assertEqual(foo(-18328.3534, 32202.3534), -18328.3534 % 32202.3534)
-        self.assertEqual(foo(18328, -32202), 18328 % -32202)
+        self.assertEqual(10 % -3, foo(10, -3))
+        self.assertEqual(-10 % 3, foo(-10, 3))
+        self.assertEqual(0 % 1.1, foo(0, 1.1))
+        self.assertEqual(-1.1 % 1.2, foo(-1.1, 1.2))
+        self.assertEqual(1 % 1, foo(1, 1))
+        self.assertEqual(-5 % -8, foo(-5, -8))
+        self.assertEqual(5 % -8, foo(5, -8))
+        self.assertEqual(5.5 % -8.3, foo(5.5, -8.3))
+        self.assertEqual(5 % 7, foo(5, 7))
+        self.assertEqual(-5 % 7, foo(-5, 7))
+        self.assertEqual(-5.34 % 7.68, foo(-5.34, 7.68))
+        self.assertEqual(18328 % 32202, foo(18328, 32202))
+        self.assertEqual(32202 % 18328, foo(32202, 18328))
+        self.assertEqual(-18328 % 32202, foo(-18328, 32202))
+        self.assertEqual(-18328.3534 % 32202.3534, foo(-18328.3534, 32202.3534))
+        self.assertEqual(18328 % -32202, foo(18328, -32202))
 
     def test_float_floordiv(self):
         # numpy float64/float64 = float 64
@@ -224,14 +224,14 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
             return a // b
 
         foo = self.helper(foo)
-        self.assertAlmostEquals(foo(0, 1.213), 0 // 1.213)
-        self.assertAlmostEquals(foo(0, 1.213), 0 // 1.213)
-        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 // 1.213)
-        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 // 1.1)
-        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 // (-8.0001))
-        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 // 7.287953)
-        self.assertEqual(foo(5, -2), -3)
-        self.assertEqual(foo(5, 2), 2)
+        self.assertAlmostEquals(0 // 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0 // 1.213, foo(0, 1.213))
+        self.assertAlmostEquals(0.1 // 1.213, foo(0.1, 1.213))
+        self.assertAlmostEquals(-1.1 // 1.1, foo(-1.1, 1.1))
+        self.assertAlmostEquals(-5.9 // (-8.0001), foo(-5.9, -8.0001))
+        self.assertAlmostEquals(5.34 // 7.287953, foo(5.34, 7.287953))
+        self.assertEqual(-3, foo(5, -2))
+        self.assertEqual(2, foo(5, 2))
 
     def test_float_min(self):
         def foo(a: float64, b: float64) -> float64:
@@ -261,9 +261,9 @@ class TestMLIRMixedArithmeticOp(unittest.TestCase):
         return f
 
     def mixed_run_helper(self, int_a, float_b, f):
-        self.assertAlmostEquals(self.foo1(int_a, float_b), f(int_a, float_b))
-        self.assertAlmostEquals(self.foo2(float_b, int_a), f(float_b, int_a))
-        self.assertAlmostEquals(self.foo3(float_b, int_a), f(float_b, int_a), places=3)
+        self.assertAlmostEquals(f(int_a, float_b), self.foo1(int_a, float_b))
+        self.assertAlmostEquals(f(float_b, int_a), self.foo2(float_b, int_a))
+        self.assertAlmostEquals(f(float_b, int_a), self.foo3(float_b, int_a), places=3)
 
     def test_Mixed_add(self):
         def foo1(a: int32, b: float64) -> float64:
@@ -341,11 +341,6 @@ class TestMLIRMixedArithmeticOp(unittest.TestCase):
         self.mixed_run_helper(-1, 1.1, lambda a, b: a / b)
         self.mixed_run_helper(-5, -8.0001, lambda a, b: a / b)
         self.mixed_run_helper(5, 7.287953, lambda a, b: a / b)
-
-    def test(self):
-        def foo1(a: float64, b: int32) -> float64:
-            return a % b
-        foo1 = self.helper(foo1)
 
     def test_Mixed_rem(self):
         def foo1(a: int32, b: float64) -> float64:

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -246,6 +246,171 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         # foo = self.helper(foo)
 
 
+class TestMLIRMixedArithmeticOp(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        f = compile_linalg(p)
+        return f
+
+    def mixed_run_helper(self, int_a, float_b, f):
+        self.assertAlmostEquals(self.foo1(int_a, float_b), f(int_a, float_b))
+        self.assertAlmostEquals(self.foo2(float_b, int_a), f(float_b, int_a))
+        self.assertAlmostEquals(self.foo3(float_b, int_a), f(float_b, int_a), places=3)
+
+    def test_Mixed_add(self):
+        def foo1(a: int32, b: float64) -> float64:
+            return a + b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a + b
+
+        def foo3(a: float32, b: int32) -> float32:
+            return a + b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+
+        self.mixed_run_helper(0, 1.213, lambda a, b: a + b)
+        self.mixed_run_helper(-1, 1.1, lambda a, b: a + b)
+        self.mixed_run_helper(-5, -8.0001, lambda a, b: a + b)
+        self.mixed_run_helper(5, 7.287953, lambda a, b: a + b)
+
+    def test_Mixed_sub(self):
+        def foo1(a: int32, b: float64) -> float64:
+            return a - b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a - b
+
+        def foo3(a: float32, b: int32) -> float32:
+            return a - b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+
+        self.mixed_run_helper(0, 1.213, lambda a, b: a - b)
+        self.mixed_run_helper(-1, 1.1, lambda a, b: a - b)
+        self.mixed_run_helper(-5, -8.0001, lambda a, b: a - b)
+        self.mixed_run_helper(5, 7.287953, lambda a, b: a - b)
+
+    def test_Mixed_mul(self):
+        def foo1(a: int32, b: float64) -> float64:
+            return a * b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a * b
+
+        def foo3(a: float32, b: int32) -> float32:
+            return a * b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+
+        self.mixed_run_helper(0, 1.213, lambda a, b: a * b)
+        self.mixed_run_helper(-1, 1.1, lambda a, b: a * b)
+        self.mixed_run_helper(-5, -8.0001, lambda a, b: a * b)
+        self.mixed_run_helper(5, 7.287953, lambda a, b: a * b)
+
+    def test_Mixed_div(self):
+        def foo1(a: int32, b: float64) -> float64:
+            return a / b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a / b
+
+        # numpy float32/int32 = float 64
+        def foo3(a: float32, b: int32) -> float64:
+            return a / b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+
+        self.mixed_run_helper(6, 1.213, lambda a, b: a / b)
+        self.mixed_run_helper(-1, 1.1, lambda a, b: a / b)
+        self.mixed_run_helper(-5, -8.0001, lambda a, b: a / b)
+        self.mixed_run_helper(5, 7.287953, lambda a, b: a / b)
+
+    def test(self):
+        def foo1(a: float64, b: int32) -> float64:
+            return a % b
+        foo1 = self.helper(foo1)
+
+    def test_Mixed_rem(self):
+        def foo1(a: int32, b: float64) -> float64:
+            return a % b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a % b
+
+        def foo3(a: float32, b: int32) -> float64:
+            return a % b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+        self.mixed_run_helper(10, -3, lambda a, b: a % b)
+        self.mixed_run_helper(-10, 3, lambda a, b: a % b)
+        self.mixed_run_helper(1, 1, lambda a, b: a % b)
+        self.mixed_run_helper(-5, -8, lambda a, b: a % b)
+        self.mixed_run_helper(5, -8, lambda a, b: a % b)
+        self.mixed_run_helper(5, -8.3, lambda a, b: a % b)
+        self.mixed_run_helper(5, 7, lambda a, b: a % b)
+        self.mixed_run_helper(-5, 7, lambda a, b: a % b)
+        self.mixed_run_helper(5, 7, lambda a, b: a % b)
+        self.mixed_run_helper(-5, 7.68, lambda a, b: a % b)
+        self.mixed_run_helper(18328, 32202, lambda a, b: a % b)
+        self.mixed_run_helper(32202, 18328, lambda a, b: a % b)
+        self.mixed_run_helper(-18328, 32202, lambda a, b: a % b)
+        self.mixed_run_helper(-18328, 32202.3534, lambda a, b: a % b)
+        self.mixed_run_helper(18328, -32202, lambda a, b: a % b)
+
+    def test_Mixed_floordiv(self):
+        # numpy float64/float64 = float 64
+        def foo1(a: int32, b: float64) -> float64:
+            return a // b
+
+        def foo2(a: float64, b: int32) -> float64:
+            return a // b
+
+        def foo3(a: float32, b: int32) -> float64:
+            return a // b
+
+        self.foo1 = self.helper(foo1)
+        self.foo2 = self.helper(foo2)
+        self.foo3 = self.helper(foo3)
+
+        self.mixed_run_helper(6, 1.213, lambda a, b: a // b)
+        self.mixed_run_helper(-1, 1.1, lambda a, b: a // b)
+        self.mixed_run_helper(-5, -8.0001, lambda a, b: a // b)
+        self.mixed_run_helper(5, 7.287953, lambda a, b: a // b)
+        self.mixed_run_helper(5, -2, lambda a, b: a // b)
+        self.mixed_run_helper(5, 2, lambda a, b: a // b)
+
+    def test_Mixed_min(self):
+        def foo(a: float64, b: float64) -> float64:
+            return min(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)
+
+    def test_Mixed_max(self):
+        def foo(a: float64, b: float64) -> float64:
+            return max(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)
+
+
 if __name__ == "__main__":
     import logging
 

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -171,7 +171,7 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 - (-8.0001))
         self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 - 7.287953)
 
-    def test_int_mul(self):
+    def test_float_mul(self):
         def foo(a: float64, b: float64) -> float64:
             return a * b
 
@@ -183,7 +183,7 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 * (-8.0001))
         self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 * 7.287953)
 
-    def test_int_div(self):
+    def test_float_div(self):
         # numpy int32/int32 = float 64
         def foo(a: float64, b: float64) -> float64:
             return a / b
@@ -196,7 +196,7 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 / (-8.0001))
         self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 / 7.287953)
 
-    def test_int_rem(self):
+    def test_float_rem(self):
         def foo(a: float64, b: float64) -> float64:
             return a % b
 
@@ -218,7 +218,7 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertEqual(foo(-18328.3534, 32202.3534), -18328.3534 % 32202.3534)
         self.assertEqual(foo(18328, -32202), 18328 % -32202)
 
-    def test_int_floordiv(self):
+    def test_float_floordiv(self):
         # numpy float64/float64 = float 64
         def foo(a: float64, b: float64) -> float64:
             return a // b
@@ -233,14 +233,21 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertEqual(foo(5, -2), -3)
         self.assertEqual(foo(5, 2), 2)
 
-    def test_int_min(self):
+    def test_float_min(self):
         def foo(a: float64, b: float64) -> float64:
             return min(a, b)
         # todo not supported yet
         # foo = self.helper(foo)
 
-    def test_int_max(self):
+    def test_float_max(self):
         def foo(a: float64, b: float64) -> float64:
             return max(a, b)
         # todo not supported yet
         # foo = self.helper(foo)
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -115,6 +115,8 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
         self.assertEqual(foo(1, 1), 1 // 1)
         self.assertEqual(foo(-5, -8), -5 // -8)
         self.assertEqual(foo(5, 7), 5 // 7)
+        self.assertEqual(foo(5, -2), -3)
+        self.assertEqual(foo(5, 2), 2)
 
     def test_int_min(self):
         def foo(a: int32, b: int32) -> int32:
@@ -227,6 +229,8 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 // 1.1)
         self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 // (-8.0001))
         self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 // 7.287953)
+        self.assertEqual(foo(5, -2), -3)
+        self.assertEqual(foo(5, 2), 2)
 
     def test_int_min(self):
         def foo(a: float64, b: float64) -> float64:

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -219,7 +219,8 @@ class TestMLIRFloatArithmeticOp(unittest.TestCase):
         self.assertEqual(foo(18328, -32202), 18328 % -32202)
 
     def test_int_floordiv(self):
-        def foo(a: float64, b: float64) -> int32:
+        # numpy float64/float64 = float 64
+        def foo(a: float64, b: float64) -> float64:
             return a // b
 
         foo = self.helper(foo)

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -1,0 +1,241 @@
+#  Copyright 2023 ByteDance Ltd. and/or its affiliates.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import unittest
+
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.compile_linalg import compile_linalg
+from matx.kernel.typing import int32, float32, float64, boolean
+
+
+class TestMLIRIntArithmeticOp(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        f = compile_linalg(p)
+        return f
+
+    def test_int_add(self):
+        def foo(a: int32, b: int32) -> int32:
+            return a + b
+
+        foo = self.helper(foo)
+
+        self.assertEqual(foo(0, 1), 1)
+        self.assertEqual(foo(-1, 1), 0)
+        self.assertEqual(foo(-5, -8), -13)
+        self.assertEqual(foo(5, 7), 12)
+        # overflow case
+        self.assertEqual(foo(2147483647, 1), -2147483648)
+        self.assertEqual(foo(-2147483648, -1), 2147483647)
+
+    def test_int_sub(self):
+        def foo(a: int32, b: int32) -> int32:
+            return a - b
+
+        foo = self.helper(foo)
+
+        self.assertEqual(foo(0, 1), -1)
+        self.assertEqual(foo(-1, 1), -2)
+        self.assertEqual(foo(1, 1), 0)
+        self.assertEqual(foo(-5, -8), 3)
+        self.assertEqual(foo(5, 7), -2)
+
+    def test_int_mul(self):
+        def foo(a: int32, b: int32) -> int32:
+            return a * b
+
+        foo = self.helper(foo)
+        self.assertEqual(foo(0, 1), 0)
+        self.assertEqual(foo(-1, 1), -1)
+        self.assertEqual(foo(1, 1), 1)
+        self.assertEqual(foo(-5, -8), 40)
+        self.assertEqual(foo(5, 7), 35)
+
+    def test_int_div(self):
+        # numpy int32/int32 = float 64
+        def foo(a: int32, b: int32) -> float64:
+            return a / b
+
+        foo = self.helper(foo)
+        self.assertEqual(foo(0, 1), 0 / 1)
+        self.assertEqual(foo(-1, 1), -1 / 1)
+        self.assertEqual(foo(1, 1), 1 / 1)
+        self.assertEqual(foo(-5, -8), -5 / -8)
+        self.assertEqual(foo(5, 7), 5 / 7)
+
+    def test_int_rem(self):
+        def foo(a: int32, b: int32) -> int32:
+            return a % b
+
+        foo = self.helper(foo)
+        self.assertEqual(foo(-10, 3), -10 % 3)
+        self.assertEqual(foo(0, 1), 0 % 1)
+        self.assertEqual(foo(-1, 1), -1 % 1)
+        self.assertEqual(foo(1, 1), 1 % 1)
+        self.assertEqual(foo(-5, -8), -5 % -8)
+        self.assertEqual(foo(5, -8), 5 % -8)
+        self.assertEqual(foo(5, 7), 5 % 7)
+        self.assertEqual(foo(-5, 7), -5 % 7)
+        self.assertEqual(foo(18328, 32202), 18328 % 32202)
+        self.assertEqual(foo(32202, 18328), 32202 % 18328)
+        self.assertEqual(foo(-18328, 32202), -18328 % 32202)
+        self.assertEqual(foo(18328, -32202), 18328 % -32202)
+
+    def test_int_floordiv(self):
+        def foo(a: int32, b: int32) -> int32:
+            return a // b
+
+        foo = self.helper(foo)
+        self.assertEqual(foo(0, 1), 0 // 1)
+        self.assertEqual(foo(-1, 1), -1 // 1)
+        self.assertEqual(foo(1, 1), 1 // 1)
+        self.assertEqual(foo(-5, -8), -5 // -8)
+        self.assertEqual(foo(5, 7), 5 // 7)
+
+    def test_int_min(self):
+        def foo(a: int32, b: int32) -> int32:
+            return min(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)
+
+    def test_int_max(self):
+        def foo(a: int32, b: int32) -> int32:
+            return max(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)
+
+
+class TestMLIRFloatArithmeticOp(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        f = compile_linalg(p)
+        return f
+
+    def test_float_add(self):
+        def foo(a: float64, b: float64) -> float64:
+            return a + b
+
+        foo = self.helper(foo)
+
+        self.assertAlmostEquals(foo(0, 1.213), 1.213)
+        self.assertAlmostEquals(foo(0, 1.213), 1.213)
+        self.assertAlmostEquals(foo(0.1, 1.213), 1.313)
+        self.assertAlmostEquals(foo(-1.1, 1.1), 0)
+        self.assertAlmostEquals(foo(-5.9, -8.0001), -13.9001)
+        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 + 7.287953)
+
+    def test_float_sub(self):
+        def foo(a: float64, b: float64) -> float64:
+            return a - b
+
+        foo = self.helper(foo)
+
+        self.assertAlmostEquals(foo(0, 1.213), -1.213)
+        self.assertAlmostEquals(foo(0, 1.213), -1.213)
+        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 - 1.213)
+        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 - 1.1)
+        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 - (-8.0001))
+        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 - 7.287953)
+
+    def test_int_mul(self):
+        def foo(a: float64, b: float64) -> float64:
+            return a * b
+
+        foo = self.helper(foo)
+        self.assertAlmostEquals(foo(0, 1.213), 0 * 1.213)
+        self.assertAlmostEquals(foo(0, 1.213), 0 * 1.213)
+        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 * 1.213)
+        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 * 1.1)
+        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 * (-8.0001))
+        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 * 7.287953)
+
+    def test_int_div(self):
+        # numpy int32/int32 = float 64
+        def foo(a: float64, b: float64) -> float64:
+            return a / b
+
+        foo = self.helper(foo)
+        self.assertAlmostEquals(foo(0, 1.213), 0 / 1.213)
+        self.assertAlmostEquals(foo(0, 1.213), 0 / 1.213)
+        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 / 1.213)
+        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 / 1.1)
+        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 / (-8.0001))
+        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 / 7.287953)
+
+    def test_int_rem(self):
+        def foo(a: float64, b: float64) -> float64:
+            return a % b
+
+        foo = self.helper(foo)
+        self.assertEqual(foo(10, -3), 10 % -3)
+        self.assertEqual(foo(-10, 3), -10 % 3)
+        self.assertEqual(foo(0, 1.1), 0 % 1.1)
+        self.assertEqual(foo(-1.1, 1.2), -1.1 % 1.2)
+        self.assertEqual(foo(1, 1), 1 % 1)
+        self.assertEqual(foo(-5, -8), -5 % -8)
+        self.assertEqual(foo(5, -8), 5 % -8)
+        self.assertEqual(foo(5.5, -8.3), 5.5 % -8.3)
+        self.assertEqual(foo(5, 7), 5 % 7)
+        self.assertEqual(foo(-5, 7), -5 % 7)
+        self.assertEqual(foo(-5.34, 7.68), -5.34 % 7.68)
+        self.assertEqual(foo(18328, 32202), 18328 % 32202)
+        self.assertEqual(foo(32202, 18328), 32202 % 18328)
+        self.assertEqual(foo(-18328, 32202), -18328 % 32202)
+        self.assertEqual(foo(-18328.3534, 32202.3534), -18328.3534 % 32202.3534)
+        self.assertEqual(foo(18328, -32202), 18328 % -32202)
+
+    def test_int_floordiv(self):
+        def foo(a: float64, b: float64) -> int32:
+            return a // b
+
+        foo = self.helper(foo)
+        self.assertAlmostEquals(foo(0, 1.213), 0 // 1.213)
+        self.assertAlmostEquals(foo(0, 1.213), 0 // 1.213)
+        self.assertAlmostEquals(foo(0.1, 1.213), 0.1 // 1.213)
+        self.assertAlmostEquals(foo(-1.1, 1.1), -1.1 // 1.1)
+        self.assertAlmostEquals(foo(-5.9, -8.0001), -5.9 // (-8.0001))
+        self.assertAlmostEquals(foo(5.34, 7.287953), 5.34 // 7.287953)
+
+    def test_int_min(self):
+        def foo(a: float64, b: float64) -> float64:
+            return min(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)
+
+    def test_int_max(self):
+        def foo(a: float64, b: float64) -> float64:
+            return max(a, b)
+        # todo not supported yet
+        # foo = self.helper(foo)

--- a/test/kernel/test_scalar_boolean_op.py
+++ b/test/kernel/test_scalar_boolean_op.py
@@ -1,0 +1,86 @@
+#  Copyright 2023 ByteDance Ltd. and/or its affiliates.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import unittest
+
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.compile_linalg import compile_linalg
+from matx.kernel.typing import int32, float32, float64, boolean
+
+
+class TestMLIRBooleanOp(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        f = compile_linalg(p)
+        return f
+
+    def test_and(self):
+        def foo(a: boolean, b: boolean) -> boolean:
+            return a and b
+
+        foo = self.helper(foo)
+        self.assertFalse(foo(0, 0))
+        self.assertFalse(foo(0, 1))
+        self.assertFalse(foo(1, 0))
+        self.assertTrue(foo(1, 1))
+        self.assertFalse(foo(False, False))
+        self.assertFalse(foo(False, True))
+        self.assertFalse(foo(True, False))
+        self.assertTrue(foo(True, True))
+
+    def test_or(self):
+        def foo(a: boolean, b: boolean) -> boolean:
+            return a or b
+
+        foo = self.helper(foo)
+        self.assertFalse(foo(0, 0))
+        self.assertTrue(foo(0, 1))
+        self.assertTrue(foo(1, 0))
+        self.assertTrue(foo(1, 1))
+        self.assertFalse(foo(False, False))
+        self.assertTrue(foo(False, True))
+        self.assertTrue(foo(True, False))
+        self.assertTrue(foo(True, True))
+
+    def test_not(self):
+        def foo(a: boolean) -> boolean:
+            return not a
+
+        foo = self.helper(foo)
+        self.assertFalse(foo(True))
+        self.assertTrue(foo(False))
+
+    def test_mixed(self):
+        def foo(a: boolean, b: boolean, c: boolean) -> boolean:
+            return not a
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()

--- a/test/kernel/test_scalar_boolean_op.py
+++ b/test/kernel/test_scalar_boolean_op.py
@@ -18,6 +18,7 @@
 #  under the License.
 
 import unittest
+import itertools
 
 from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
@@ -74,9 +75,37 @@ class TestMLIRBooleanOp(unittest.TestCase):
         self.assertFalse(foo(True))
         self.assertTrue(foo(False))
 
-    def test_mixed(self):
+    def test_more_op1(self):
         def foo(a: boolean, b: boolean, c: boolean) -> boolean:
-            return not a
+            return a and b or not c
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([False, True], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+    def test_more_op2(self):
+        def foo(a: boolean, b: boolean, c: boolean) -> boolean:
+            return not (a and b) or (not c and a)
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([False, True], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+    def test_more_op3(self):
+        def foo(a: boolean, b: boolean, c: boolean) -> boolean:
+            return not (not (a and b) or (not c and a))
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([False, True], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+    def test_more_op4(self):
+        def foo(a: boolean, b: boolean, c: boolean) -> boolean:
+            return not a or not b and c and a or b
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([False, True], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
 
 
 if __name__ == "__main__":

--- a/test/kernel/test_scalar_compare.py
+++ b/test/kernel/test_scalar_compare.py
@@ -21,7 +21,7 @@ import unittest
 
 from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
-from matx.kernel.typing import int32, float32, boolean
+from matx.kernel.typing import int32, float32, float64, boolean
 
 
 class TestMLIRIntComparsion(unittest.TestCase):
@@ -35,47 +35,153 @@ class TestMLIRIntComparsion(unittest.TestCase):
         print()
         print("=" * 30, "compile and run", "=" * 30, sep="")
         print()
-        # a = 1
-        # b = 2
         f = compile_linalg(p)
-        # f(a, b)
-        # np.testing.assert_equal(rt, foo(a))
+        return f
 
     def test_int_eq(self):
         def foo(a: int32, b: int32) -> boolean:
             return a == b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+
+        self.assertTrue(foo(-2, -2))
+        self.assertTrue(foo(-1, -1))
+        self.assertTrue(foo(-1000, -1000))
+        self.assertTrue(foo(0, 0))
+        self.assertTrue(foo(1, 1))
+        self.assertTrue(foo(2, 2))
+
+        self.assertFalse(foo(-100, -2))
+        self.assertFalse(foo(-2, -100))
+        self.assertFalse(foo(1, -1))
+        self.assertFalse(foo(1, 0))
+        self.assertFalse(foo(0, 1))
+        self.assertFalse(foo(2, 200))
 
     def test_int_ne(self):
         def foo(a: int32, b: int32) -> boolean:
             return a != b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+
+        self.assertFalse(foo(-2, -2))
+        self.assertFalse(foo(-1, -1))
+        self.assertFalse(foo(-1000, -1000))
+        self.assertFalse(foo(0, 0))
+        self.assertFalse(foo(1, 1))
+        self.assertFalse(foo(2, 2))
+
+        self.assertTrue(foo(-100, -2))
+        self.assertTrue(foo(-2, -100))
+        self.assertTrue(foo(1, -1))
+        self.assertTrue(foo(1, 0))
+        self.assertTrue(foo(0, 1))
+        self.assertTrue(foo(2, 200))
 
     def test_int_lt(self):
         def foo(a: int32, b: int32) -> boolean:
             return a < b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+
+        self.assertFalse(foo(-2, -2))
+        self.assertFalse(foo(-1, -1))
+        self.assertFalse(foo(-1000, -1000))
+        self.assertFalse(foo(0, 0))
+        self.assertFalse(foo(1, 1))
+        self.assertFalse(foo(2, 2))
+
+        self.assertTrue(foo(-100, -2))
+        self.assertTrue(foo(-1, 0))
+        self.assertTrue(foo(0, 1))
+        self.assertTrue(foo(-1, 1))
+        self.assertTrue(foo(1, 3))
+        self.assertTrue(foo(2, 200))
+
+        self.assertFalse(foo(-2, -100))
+        self.assertFalse(foo(0, -1))
+        self.assertFalse(foo(1, 0))
+        self.assertFalse(foo(1, -1))
+        self.assertFalse(foo(3, 1))
+        self.assertFalse(foo(200, 2))
 
     def test_int_le(self):
         def foo(a: int32, b: int32) -> boolean:
             return a <= b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+        self.assertTrue(foo(-2, -2))
+        self.assertTrue(foo(-1, -1))
+        self.assertTrue(foo(-1000, -1000))
+        self.assertTrue(foo(0, 0))
+        self.assertTrue(foo(1, 1))
+        self.assertTrue(foo(2, 2))
+
+        self.assertTrue(foo(-100, -2))
+        self.assertTrue(foo(-1, 0))
+        self.assertTrue(foo(0, 1))
+        self.assertTrue(foo(-1, 1))
+        self.assertTrue(foo(1, 3))
+        self.assertTrue(foo(2, 200))
+
+        self.assertFalse(foo(-2, -100))
+        self.assertFalse(foo(0, -1))
+        self.assertFalse(foo(1, 0))
+        self.assertFalse(foo(1, -1))
+        self.assertFalse(foo(3, 1))
+        self.assertFalse(foo(200, 2))
 
     def test_int_gt(self):
         def foo(a: int32, b: int32) -> boolean:
             return a > b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+        self.assertFalse(foo(-2, -2))
+        self.assertFalse(foo(-1, -1))
+        self.assertFalse(foo(-1000, -1000))
+        self.assertFalse(foo(0, 0))
+        self.assertFalse(foo(1, 1))
+        self.assertFalse(foo(2, 2))
+
+        self.assertFalse(foo(-100, -2))
+        self.assertFalse(foo(-1, 0))
+        self.assertFalse(foo(0, 1))
+        self.assertFalse(foo(-1, 1))
+        self.assertFalse(foo(1, 3))
+        self.assertFalse(foo(2, 200))
+
+        self.assertTrue(foo(-2, -100))
+        self.assertTrue(foo(0, -1))
+        self.assertTrue(foo(1, 0))
+        self.assertTrue(foo(1, -1))
+        self.assertTrue(foo(3, 1))
+        self.assertTrue(foo(200, 2))
 
     def test_int_ge(self):
         def foo(a: int32, b: int32) -> boolean:
             return a >= b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+        self.assertTrue(foo(-2, -2))
+        self.assertTrue(foo(-1, -1))
+        self.assertTrue(foo(-1000, -1000))
+        self.assertTrue(foo(0, 0))
+        self.assertTrue(foo(1, 1))
+        self.assertTrue(foo(2, 2))
+
+        self.assertFalse(foo(-100, -2))
+        self.assertFalse(foo(-1, 0))
+        self.assertFalse(foo(0, 1))
+        self.assertFalse(foo(-1, 1))
+        self.assertFalse(foo(1, 3))
+        self.assertFalse(foo(2, 200))
+
+        self.assertTrue(foo(-2, -100))
+        self.assertTrue(foo(0, -1))
+        self.assertTrue(foo(1, 0))
+        self.assertTrue(foo(1, -1))
+        self.assertTrue(foo(3, 1))
+        self.assertTrue(foo(200, 2))
 
 
 class TestMLIRFloatComparsion(unittest.TestCase):
@@ -89,44 +195,303 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         print()
         print("=" * 30, "compile and run", "=" * 30, sep="")
         print()
-        # a = 1
-        # b = 2
         f = compile_linalg(p)
-        # f(a, b)
-        # np.testing.assert_equal(rt, foo(a))
+        return f
 
     def test_float_eq(self):
         def foo(a: float32, b: float32) -> boolean:
             return a == b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+
+        self.assertTrue(foo(-2.1, -2.1))
+        self.assertTrue(foo(-1.3, -1.3))
+        self.assertTrue(foo(-1000.233, -1000.233))
+        self.assertTrue(foo(0, 0))
+        self.assertTrue(foo(0.00000001, 0.00000001))
+        self.assertTrue(foo(2.3, 2.3))
+
+        self.assertFalse(foo(-100.231, -2.455))
+        self.assertFalse(foo(-2, -100.1313))
+        self.assertFalse(foo(1.1, -1.1))
+        self.assertFalse(foo(1.2, 0))
+        self.assertFalse(foo(1, 1.0000001))
+        self.assertFalse(foo(1, 0.0000009))
+        self.assertFalse(foo(2.9, 200.1))
+
+        # test orderness
+        self.assertFalse(foo(-2, float("nan")))
+        self.assertFalse(foo(float("nan"), -2.5))
+        self.assertFalse(foo(-100, float("nan")))
+        self.assertFalse(foo(float("nan"), -2))
+        self.assertFalse(foo(-2, float("nan")))
+        self.assertFalse(foo(float("nan"), -2.00001))
 
     def test_float_ne(self):
         def foo(a: float32, b: float32) -> boolean:
             return a != b
 
-        self.helper(foo)
+        foo = self.helper(foo)
+
+        self.assertFalse(foo(-2.1, -2.1))
+        self.assertFalse(foo(-1.3, -1.3))
+        self.assertFalse(foo(-1000.233, -1000.233))
+        self.assertFalse(foo(0, 0))
+        self.assertFalse(foo(0.00000001, 0.00000001))
+        self.assertFalse(foo(2.3, 2.3))
+
+        self.assertTrue(foo(-100.231, -2.455))
+        self.assertTrue(foo(-2, -100.1313))
+        self.assertTrue(foo(1.1, -1.1))
+        self.assertTrue(foo(1.2, 0))
+        self.assertTrue(foo(1, 1.0000001))
+        self.assertTrue(foo(1, 0.0000009))
+        self.assertTrue(foo(2.9, 200.1))
+
+        # test orderness
+        self.assertFalse(foo(-2, float("nan")))
+        self.assertFalse(foo(float("nan"), -2.5))
+        self.assertFalse(foo(-100, float("nan")))
+        self.assertFalse(foo(float("nan"), -2))
+        self.assertFalse(foo(-2, float("nan")))
+        self.assertFalse(foo(float("nan"), -2.00001))
 
     def test_float_lt(self):
-        def foo(a: float32, b: float32) -> boolean:
+        def foo_32(a: float32, b: float32) -> boolean:
             return a < b
 
-        self.helper(foo)
+        def foo_64(a: float64, b: float64) -> boolean:
+            return a < b
+
+        foo_32 = self.helper(foo_32)
+        foo_64 = self.helper(foo_64)
+
+        self.assertFalse(foo_32(-2, -2))
+        self.assertFalse(foo_32(-2.5, -2.5))
+        self.assertFalse(foo_32(-1, -1))
+        self.assertFalse(foo_32(-1.8, -1.8))
+        self.assertFalse(foo_32(-1000, -1000))
+        self.assertFalse(foo_32(-1000.0, -1000.0))
+        self.assertFalse(foo_32(0.1, 0.1))
+        self.assertFalse(foo_32(0.0, 0.0))
+        self.assertFalse(foo_32(1.00000001, 1.00000001))
+        self.assertFalse(foo_32(2, 2))
+        self.assertFalse(foo_32(2.6, 2.6))
+
+        self.assertTrue(foo_32(-100, -2))
+        self.assertTrue(foo_32(-2.00001, -2))
+        self.assertTrue(foo_32(-0.0001, 0))
+        self.assertTrue(foo_32(-1.346456, 0))
+        self.assertTrue(foo_32(0, 1.7823))
+        self.assertTrue(foo_32(0, 0.000001))
+        self.assertTrue(foo_32(-1, 1))
+        self.assertTrue(foo_32(1.9999, 2.000))
+        self.assertTrue(foo_32(2.1, 200.96))
+        # due to floating point precision, use float64
+        #self.assertTrue(foo_32(1, 1.000000000001))
+        #self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
+        self.assertTrue(foo_64(1, 1.000000000001))
+        self.assertTrue(foo_64(1.00000000000001, 1.000000000001))
+
+        self.assertFalse(foo_32(-2, -100))
+        self.assertFalse(foo_32(-2, -2.00001))
+        self.assertFalse(foo_32(0, -0.0001))
+        self.assertFalse(foo_32(0, -1.346456))
+        self.assertFalse(foo_32(1.7823, 0))
+        self.assertFalse(foo_32(0.000001, 0))
+        self.assertFalse(foo_32(1, -1))
+        self.assertFalse(foo_32(2.000, 1.9999))
+        self.assertFalse(foo_32(200.96, 2.1))
+        # due to floating point precision, use float64
+        #self.assertFalse(foo_32(1.000000000001, 1))
+        #self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
+        self.assertFalse(foo_64(1.000000000001, 1))
+        self.assertFalse(foo_64(1.000000000001, 1.00000000000001))
+
+        # test orderness
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.5))
+        self.assertFalse(foo_32(-100, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2))
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.00001))
 
     def test_float_le(self):
-        def foo(a: float32, b: float32) -> boolean:
+        def foo_32(a: float32, b: float32) -> boolean:
             return a <= b
 
-        self.helper(foo)
+        def foo_64(a: float64, b: float64) -> boolean:
+            return a <= b
+
+        foo_32 = self.helper(foo_32)
+        foo_64 = self.helper(foo_64)
+
+        self.assertTrue(foo_32(-2, -2))
+        self.assertTrue(foo_32(-2.5, -2.5))
+        self.assertTrue(foo_32(-1, -1))
+        self.assertTrue(foo_32(-1.8, -1.8))
+        self.assertTrue(foo_32(-1000, -1000))
+        self.assertTrue(foo_32(-1000.0, -1000.0))
+        self.assertTrue(foo_32(0.1, 0.1))
+        self.assertTrue(foo_32(0.0, 0.0))
+        self.assertTrue(foo_32(1.00000001, 1.00000001))
+        self.assertTrue(foo_32(2, 2))
+        self.assertTrue(foo_32(2.6, 2.6))
+
+        self.assertTrue(foo_32(-100, -2))
+        self.assertTrue(foo_32(-2.00001, -2))
+        self.assertTrue(foo_32(-0.0001, 0))
+        self.assertTrue(foo_32(-1.346456, 0))
+        self.assertTrue(foo_32(0, 1.7823))
+        self.assertTrue(foo_32(0, 0.000001))
+        self.assertTrue(foo_32(-1, 1))
+        self.assertTrue(foo_32(1.9999, 2.000))
+        self.assertTrue(foo_32(2.1, 200.96))
+        # due to floating point precision, use float64
+        #self.assertTrue(foo_32(1, 1.000000000001))
+        #self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
+        self.assertTrue(foo_64(1, 1.000000000001))
+        self.assertTrue(foo_64(1.00000000000001, 1.000000000001))
+
+        self.assertFalse(foo_32(-2, -100))
+        self.assertFalse(foo_32(-2, -2.00001))
+        self.assertFalse(foo_32(0, -0.0001))
+        self.assertFalse(foo_32(0, -1.346456))
+        self.assertFalse(foo_32(1.7823, 0))
+        self.assertFalse(foo_32(0.000001, 0))
+        self.assertFalse(foo_32(1, -1))
+        self.assertFalse(foo_32(2.000, 1.9999))
+        self.assertFalse(foo_32(200.96, 2.1))
+        # due to floating point precision, use float64
+        #self.assertFalse(foo_32(1.000000000001, 1))
+        #self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
+        self.assertFalse(foo_64(1.000000000001, 1))
+        self.assertFalse(foo_64(1.000000000001, 1.00000000000001))
+
+        # test orderness
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.5))
+        self.assertFalse(foo_32(-100, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2))
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.00001))
 
     def test_float_gt(self):
-        def foo(a: float32, b: float32) -> boolean:
+        def foo_32(a: float32, b: float32) -> boolean:
             return a > b
 
-        self.helper(foo)
+        def foo_64(a: float64, b: float64) -> boolean:
+            return a > b
+
+        foo_32 = self.helper(foo_32)
+        foo_64 = self.helper(foo_64)
+
+        self.assertFalse(foo_32(-2, -2))
+        self.assertFalse(foo_32(-2.5, -2.5))
+        self.assertFalse(foo_32(-1, -1))
+        self.assertFalse(foo_32(-1.8, -1.8))
+        self.assertFalse(foo_32(-1000, -1000))
+        self.assertFalse(foo_32(-1000.0, -1000.0))
+        self.assertFalse(foo_32(0.1, 0.1))
+        self.assertFalse(foo_32(0.0, 0.0))
+        self.assertFalse(foo_32(1.00000001, 1.00000001))
+        self.assertFalse(foo_32(2, 2))
+        self.assertFalse(foo_32(2.6, 2.6))
+
+        self.assertFalse(foo_32(-100, -2))
+        self.assertFalse(foo_32(-2.00001, -2))
+        self.assertFalse(foo_32(-0.0001, 0))
+        self.assertFalse(foo_32(-1.346456, 0))
+        self.assertFalse(foo_32(0, 1.7823))
+        self.assertFalse(foo_32(0, 0.000001))
+        self.assertFalse(foo_32(-1, 1))
+        self.assertFalse(foo_32(1.9999, 2.000))
+        self.assertFalse(foo_32(2.1, 200.96))
+        # due to floating point precision, use float64
+        #self.assertFalse(foo_32(1, 1.000000000001))
+        #self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
+        self.assertFalse(foo_64(1, 1.000000000001))
+        self.assertFalse(foo_64(1.00000000000001, 1.000000000001))
+
+        self.assertTrue(foo_32(-2, -100))
+        self.assertTrue(foo_32(-2, -2.00001))
+        self.assertTrue(foo_32(0, -0.0001))
+        self.assertTrue(foo_32(0, -1.346456))
+        self.assertTrue(foo_32(1.7823, 0))
+        self.assertTrue(foo_32(0.000001, 0))
+        self.assertTrue(foo_32(1, -1))
+        self.assertTrue(foo_32(2.000, 1.9999))
+        self.assertTrue(foo_32(200.96, 2.1))
+        # due to floating point precision, use float64
+        #self.assertTrue(foo_32(1.000000000001, 1))
+        #self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
+        self.assertTrue(foo_64(1.000000000001, 1))
+        self.assertTrue(foo_64(1.000000000001, 1.00000000000001))
+
+        # test orderness
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.5))
+        self.assertFalse(foo_32(-100, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2))
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.00001))
 
     def test_float_ge(self):
-        def foo(a: float32, b: float32) -> boolean:
+        def foo_32(a: float32, b: float32) -> boolean:
             return a >= b
 
-        self.helper(foo)
+        def foo_64(a: float64, b: float64) -> boolean:
+            return a >= b
+
+        foo_32 = self.helper(foo_32)
+        foo_64 = self.helper(foo_64)
+
+        self.assertTrue(foo_32(-2, -2))
+        self.assertTrue(foo_32(-2.5, -2.5))
+        self.assertTrue(foo_32(-1, -1))
+        self.assertTrue(foo_32(-1.8, -1.8))
+        self.assertTrue(foo_32(-1000, -1000))
+        self.assertTrue(foo_32(-1000.0, -1000.0))
+        self.assertTrue(foo_32(0.1, 0.1))
+        self.assertTrue(foo_32(0.0, 0.0))
+        self.assertTrue(foo_32(1.00000001, 1.00000001))
+        self.assertTrue(foo_32(2, 2))
+        self.assertTrue(foo_32(2.6, 2.6))
+
+        self.assertFalse(foo_32(-100, -2))
+        self.assertFalse(foo_32(-2.00001, -2))
+        self.assertFalse(foo_32(-0.0001, 0))
+        self.assertFalse(foo_32(-1.346456, 0))
+        self.assertFalse(foo_32(0, 1.7823))
+        self.assertFalse(foo_32(0, 0.000001))
+        self.assertFalse(foo_32(-1, 1))
+        self.assertFalse(foo_32(1.9999, 2.000))
+        self.assertFalse(foo_32(2.1, 200.96))
+        # due to floating point precision, use float64
+        #self.assertFalse(foo_32(1, 1.000000000001))
+        #self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
+        self.assertFalse(foo_64(1, 1.000000000001))
+        self.assertFalse(foo_64(1.00000000000001, 1.000000000001))
+
+        self.assertTrue(foo_32(-2, -100))
+        self.assertTrue(foo_32(-2, -2.00001))
+        self.assertTrue(foo_32(0, -0.0001))
+        self.assertTrue(foo_32(0, -1.346456))
+        self.assertTrue(foo_32(1.7823, 0))
+        self.assertTrue(foo_32(0.000001, 0))
+        self.assertTrue(foo_32(1, -1))
+        self.assertTrue(foo_32(2.000, 1.9999))
+        self.assertTrue(foo_32(200.96, 2.1))
+        # due to floating point precision, use float64
+        #self.assertTrue(foo_32(1.000000000001, 1))
+        #self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
+        self.assertTrue(foo_64(1.000000000001, 1))
+        self.assertTrue(foo_64(1.000000000001, 1.00000000000001))
+
+        # test orderness
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.5))
+        self.assertFalse(foo_32(-100, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2))
+        self.assertFalse(foo_32(-2, float("nan")))
+        self.assertFalse(foo_32(float("nan"), -2.00001))

--- a/test/kernel/test_scalar_compare.py
+++ b/test/kernel/test_scalar_compare.py
@@ -1,0 +1,132 @@
+#  Copyright 2023 ByteDance Ltd. and/or its affiliates.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import unittest
+
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.compile_linalg import compile_linalg
+from matx.kernel.typing import int32, float32, boolean
+
+
+class TestMLIRIntComparsion(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        # a = 1
+        # b = 2
+        f = compile_linalg(p)
+        # f(a, b)
+        # np.testing.assert_equal(rt, foo(a))
+
+    def test_int_eq(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a == b
+
+        self.helper(foo)
+
+    def test_int_ne(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a != b
+
+        self.helper(foo)
+
+    def test_int_lt(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a < b
+
+        self.helper(foo)
+
+    def test_int_le(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a <= b
+
+        self.helper(foo)
+
+    def test_int_gt(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a > b
+
+        self.helper(foo)
+
+    def test_int_ge(self):
+        def foo(a: int32, b: int32) -> boolean:
+            return a >= b
+
+        self.helper(foo)
+
+
+class TestMLIRFloatComparsion(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        # a = 1
+        # b = 2
+        f = compile_linalg(p)
+        # f(a, b)
+        # np.testing.assert_equal(rt, foo(a))
+
+    def test_float_eq(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a == b
+
+        self.helper(foo)
+
+    def test_float_ne(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a != b
+
+        self.helper(foo)
+
+    def test_float_lt(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a < b
+
+        self.helper(foo)
+
+    def test_float_le(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a <= b
+
+        self.helper(foo)
+
+    def test_float_gt(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a > b
+
+        self.helper(foo)
+
+    def test_float_ge(self):
+        def foo(a: float32, b: float32) -> boolean:
+            return a >= b
+
+        self.helper(foo)

--- a/test/kernel/test_scalar_compare.py
+++ b/test/kernel/test_scalar_compare.py
@@ -288,8 +288,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertTrue(foo_32(1.9999, 2.000))
         self.assertTrue(foo_32(2.1, 200.96))
         # due to floating point precision, use float64
-        #self.assertTrue(foo_32(1, 1.000000000001))
-        #self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
+        # self.assertTrue(foo_32(1, 1.000000000001))
+        # self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
         self.assertTrue(foo_64(1, 1.000000000001))
         self.assertTrue(foo_64(1.00000000000001, 1.000000000001))
 
@@ -303,8 +303,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertFalse(foo_32(2.000, 1.9999))
         self.assertFalse(foo_32(200.96, 2.1))
         # due to floating point precision, use float64
-        #self.assertFalse(foo_32(1.000000000001, 1))
-        #self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
+        # self.assertFalse(foo_32(1.000000000001, 1))
+        # self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
         self.assertFalse(foo_64(1.000000000001, 1))
         self.assertFalse(foo_64(1.000000000001, 1.00000000000001))
 
@@ -348,8 +348,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertTrue(foo_32(1.9999, 2.000))
         self.assertTrue(foo_32(2.1, 200.96))
         # due to floating point precision, use float64
-        #self.assertTrue(foo_32(1, 1.000000000001))
-        #self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
+        # self.assertTrue(foo_32(1, 1.000000000001))
+        # self.assertTrue(foo_32(1.00000000000001, 1.000000000001))
         self.assertTrue(foo_64(1, 1.000000000001))
         self.assertTrue(foo_64(1.00000000000001, 1.000000000001))
 
@@ -363,8 +363,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertFalse(foo_32(2.000, 1.9999))
         self.assertFalse(foo_32(200.96, 2.1))
         # due to floating point precision, use float64
-        #self.assertFalse(foo_32(1.000000000001, 1))
-        #self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
+        # self.assertFalse(foo_32(1.000000000001, 1))
+        # self.assertFalse(foo_32(1.000000000001, 1.00000000000001))
         self.assertFalse(foo_64(1.000000000001, 1))
         self.assertFalse(foo_64(1.000000000001, 1.00000000000001))
 
@@ -408,8 +408,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertFalse(foo_32(1.9999, 2.000))
         self.assertFalse(foo_32(2.1, 200.96))
         # due to floating point precision, use float64
-        #self.assertFalse(foo_32(1, 1.000000000001))
-        #self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
+        # self.assertFalse(foo_32(1, 1.000000000001))
+        # self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
         self.assertFalse(foo_64(1, 1.000000000001))
         self.assertFalse(foo_64(1.00000000000001, 1.000000000001))
 
@@ -423,8 +423,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertTrue(foo_32(2.000, 1.9999))
         self.assertTrue(foo_32(200.96, 2.1))
         # due to floating point precision, use float64
-        #self.assertTrue(foo_32(1.000000000001, 1))
-        #self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
+        # self.assertTrue(foo_32(1.000000000001, 1))
+        # self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
         self.assertTrue(foo_64(1.000000000001, 1))
         self.assertTrue(foo_64(1.000000000001, 1.00000000000001))
 
@@ -468,8 +468,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertFalse(foo_32(1.9999, 2.000))
         self.assertFalse(foo_32(2.1, 200.96))
         # due to floating point precision, use float64
-        #self.assertFalse(foo_32(1, 1.000000000001))
-        #self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
+        # self.assertFalse(foo_32(1, 1.000000000001))
+        # self.assertFalse(foo_32(1.00000000000001, 1.000000000001))
         self.assertFalse(foo_64(1, 1.000000000001))
         self.assertFalse(foo_64(1.00000000000001, 1.000000000001))
 
@@ -483,8 +483,8 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertTrue(foo_32(2.000, 1.9999))
         self.assertTrue(foo_32(200.96, 2.1))
         # due to floating point precision, use float64
-        #self.assertTrue(foo_32(1.000000000001, 1))
-        #self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
+        # self.assertTrue(foo_32(1.000000000001, 1))
+        # self.assertTrue(foo_32(1.000000000001, 1.00000000000001))
         self.assertTrue(foo_64(1.000000000001, 1))
         self.assertTrue(foo_64(1.000000000001, 1.00000000000001))
 

--- a/test/kernel/test_scalar_compare.py
+++ b/test/kernel/test_scalar_compare.py
@@ -495,3 +495,10 @@ class TestMLIRFloatComparsion(unittest.TestCase):
         self.assertFalse(foo_32(float("nan"), -2))
         self.assertFalse(foo_32(-2, float("nan")))
         self.assertFalse(foo_32(float("nan"), -2.00001))
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()


### PR DESCRIPTION
- support scalar comparisons
- support returning a scalar
- add more unit tests
- fix a bug related to the mod op
- update gitignore
- fix a bug related to the mod op of two different type operands
- support boolean ops
- support unary ops