### PR TITLE
[kernel]enhance the MLIR codegen printer (Part 2)

### DIFF
--- a/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
+++ b/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
@@ -60,14 +60,16 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
                         public PrimExprFunctor<void(const PrimExpr&, std::ostream&)>,
                         public HLOExprFunctor<void(const HLOExpr&, std::ostream&)>,
                         public TypeFunctor<void(const Type&, std::ostream&)> {
-  using var_name_map = std::unordered_map<const Object*, std::string>;
+  using expr_name_map = std::unordered_map<const Object*, std::string>;
+  using var_name_map = std::unordered_map<StringRef, std::string>;
   using var_type_map = std::unordered_map<const Object*, std::pair<std::string, std::string>>;
   friend class LinalgGenericPrinter;
 
  public:
-  explicit MLIRTextPrinter() : var_name_scope(1), var_type_scope(1) {
-    expr_name_map_ = &(var_name_scope.back());
+  explicit MLIRTextPrinter() : expr_name_scope(1), var_type_scope(1), var_name_scope(1) {
+    expr_name_map_ = &(expr_name_scope.back());
     val_type_map_ = &(var_type_scope.back());
+    var_name_map_ =  &(var_name_scope.back());
   }
 
   void AddFunction(const PrimFunc& fn);
@@ -157,15 +159,26 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
     }
   }
 
+  template <class... Args>
+  void insert_or_assign_var_name_map_(StringRef &key, Args&&... args) {
+    auto rt = var_name_map_->emplace(
+        std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(args...));
+    if (!rt.second) {
+      rt.first->second = std::string(args...);
+    }
+  }
+
  private:
   /*! \brief the stream to be printed */
   std::ostringstream stream_;
   std::unordered_map<const PointerTypeNode*, const Buffer> pointer_buffer_map;
   std::unordered_map<const PrimExprNode*, const std::string> index_map;
-  std::vector<var_name_map> var_name_scope;
+  std::vector<expr_name_map> expr_name_scope;
   std::vector<var_type_map> var_type_scope;
-  var_name_map* expr_name_map_;
+  std::vector<var_name_map> var_name_scope;
+  expr_name_map* expr_name_map_;
   var_type_map* val_type_map_;
+  var_name_map* var_name_map_;
   std::atomic<uint32_t> cur_index_{0};
   std::unique_ptr<LinalgGenericPrinter> computeBlockPrinter = nullptr;
 };

--- a/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
+++ b/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
@@ -68,12 +68,10 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
 
   using expr_name_map = std::unordered_map<const Object*, std::string>;
   using var_name_map = std::unordered_map<StringRef, mlir_info>;
-  using val_type_map = std::unordered_map<const Object*, std::pair<std::string, std::string>>;
   friend class LinalgGenericPrinter;
 
-  explicit MLIRTextPrinter() : expr_name_scope(1), val_type_scope(1), var_name_scope(1) {
+  explicit MLIRTextPrinter() : expr_name_scope(1), var_name_scope(1) {
     expr_name_map_ = &(expr_name_scope.back());
-    val_type_map_ = &(val_type_scope.back());
     var_name_map_ = &(var_name_scope.back());
   }
 
@@ -143,7 +141,7 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   std::string ConvertTypeToMLIR(const PointerTypeNode* node) const;
   void PrintNodeName(const BaseExpr& ptr, std::ostream& os);
 
-  std::pair<std::string, std::string> GetNodeDataType(const PrimExprNode* op);
+  std::pair<std::string, std::string> GetNodeDataType(const PrimExprNode* op) const;
 
   // Begin Type
   // Overload of Type printing functions
@@ -172,10 +170,8 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   std::unordered_map<const PointerTypeNode*, const Buffer> pointer_buffer_map;
   std::unordered_map<const PrimExprNode*, const std::string> index_map;
   std::vector<expr_name_map> expr_name_scope;
-  std::vector<val_type_map> val_type_scope;
   std::vector<var_name_map> var_name_scope;
   expr_name_map* expr_name_map_;
-  val_type_map* val_type_map_;
   var_name_map* var_name_map_;
   std::atomic<uint32_t> cur_index_{0};
   std::unique_ptr<LinalgGenericPrinter> computeBlockPrinter = nullptr;

--- a/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
+++ b/include/matxscript/ir/printer/kernel_printer/mlir_printer.h
@@ -69,7 +69,7 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   explicit MLIRTextPrinter() : expr_name_scope(1), var_type_scope(1), var_name_scope(1) {
     expr_name_map_ = &(expr_name_scope.back());
     val_type_map_ = &(var_type_scope.back());
-    var_name_map_ =  &(var_name_scope.back());
+    var_name_map_ = &(var_name_scope.back());
   }
 
   void AddFunction(const PrimFunc& fn);
@@ -160,7 +160,7 @@ class MLIRTextPrinter : public StmtFunctor<void(const Stmt&, std::ostream&)>,
   }
 
   template <class... Args>
-  void insert_or_assign_var_name_map_(StringRef &key, Args&&... args) {
+  void insert_or_assign_var_name_map_(StringRef& key, Args&&... args) {
     auto rt = var_name_map_->emplace(
         std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(args...));
     if (!rt.second) {

--- a/python/matx/kernel/ir/assign.py
+++ b/python/matx/kernel/ir/assign.py
@@ -58,7 +58,8 @@ class AssignNDArrayNode(StatementBaseNode):
             begin = tuple(self.iter_var_names)
             value = self.rhs.to_matx_ir(iter_var=self.iter_var_names, **kwargs)
             if value.checked_type != _ir.PrimType(self.lhs.kernel_type.dtype_str()):
-                raise SyntaxError(f"Cannot store {value.checked_type} to buffer of {self.lhs.kernel_type.dtype_str()}")
+                raise SyntaxError(
+                    f"Cannot store {value.checked_type} to buffer of {self.lhs.kernel_type.dtype_str()}")
             return self.lhs.buffer.vstore(begin, value)
         raise NotImplementedError(f"Unsupported assign statement lhs: {self.lhs} rhs: {self.rhs}")
         # self.lhs

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -32,8 +32,7 @@ _arithmetic_binop_maker = {
     ast.FloorDiv: lambda lhs, rhs, span: _generic.floordiv(lhs, rhs, span),
     # ast.Mod: lambda lhs, rhs, span: _generic.floormod(lhs, rhs, span),
     # quick fix for mod sign issue
-    ast.Mod: lambda lhs, rhs, span: _generic.floormod(_generic.add(_generic.floormod(lhs, rhs, span), rhs, span), rhs,
-                                                      span),
+    ast.Mod: lambda lhs, rhs, span: _generic.floormod(lhs, rhs, span),
     ast.BitOr: lambda lhs, rhs, span: _generic.bitwise_or(lhs, rhs, span),
     ast.BitAnd: lambda lhs, rhs, span: _generic.bitwise_and(lhs, rhs, span),
     ast.BitXor: lambda lhs, rhs, span: _generic.bitwise_xor(lhs, rhs, span),

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -69,11 +69,17 @@ def reset_constant_dtype(lhs: ExpressionBaseNode, rhs: ExpressionBaseNode):
         other_kernel_t = other.kernel_type
         const_dtype = const_kernel_t.dtype
         other_dtype = other_kernel_t.dtype
-        if np.can_cast(const_dtype, other_dtype, "same_kind") and np.can_cast(const.value, other_dtype, "safe"):
+        if np.can_cast(
+                const_dtype,
+                other_dtype,
+                "same_kind") and np.can_cast(
+                const.value,
+                other_dtype,
+                "safe"):
             return ConstScalarNode(const.value, PYTYPE_TO_KERNEL_TYPE[other_dtype], const.span)
         else:
             raise SyntaxError(f"Cannot cast constant {const} from {const_dtype} to {other_dtype} "
-                                f" which is the type of the other operand.")
+                              f" which is the type of the other operand.")
 
     lhs_is_constant = isinstance(lhs, ConstScalarNode)
     rhs_is_constant = isinstance(rhs, ConstScalarNode)
@@ -97,10 +103,12 @@ class CastOp(ExpressionBaseNode):
         super().__init__(self.result_type)
 
     def to_matx_ir(self, **kwargs):
-        return _generic.cast(self.operand.to_matx_ir(**kwargs), NPDTYPE_TO_STR[self.target_dtype], self.span)
+        return _generic.cast(self.operand.to_matx_ir(**kwargs),
+                             NPDTYPE_TO_STR[self.target_dtype], self.span)
 
     def buffer_regions(self, **kwargs):
         return self.operand.buffer_regions(**kwargs)
+
 
 class BinaryOp(ExpressionBaseNode):
 

--- a/python/matx/kernel/ir/ops.py
+++ b/python/matx/kernel/ir/ops.py
@@ -142,7 +142,12 @@ class BinaryOp(ExpressionBaseNode):
         self.shape = result_shape
 
     def to_matx_ir(self, **kwargs):
-        matx_result = self.op(self.lhs.to_matx_ir(**kwargs), self.rhs.to_matx_ir(**kwargs), self.span)
+        matx_result = self.op(
+            self.lhs.to_matx_ir(
+                **kwargs),
+            self.rhs.to_matx_ir(
+                **kwargs),
+            self.span)
         if matx_result.checked_type != _ir.PrimType(self.result_type.dtype_str()):
             matx_result = _generic.cast(matx_result, self.result_type.dtype_str(), self.span)
         return matx_result

--- a/python/matx/kernel/ir/scalar.py
+++ b/python/matx/kernel/ir/scalar.py
@@ -30,6 +30,7 @@ class ScalarNode(ExpressionBaseNode):
         assert is_scalar_shape(self.shape), 'sytax error'
         self.script_type = _ir.PrimType(type_.dtype_str())
         self.name: str = name
+        self.span = span
         self.script_var = _ir.PrimVar(name, self.script_type, span)
 
     def to_matx_ir(self, **kwargs):
@@ -40,6 +41,7 @@ class ConstScalarNode(ScalarNode):
 
     def __init__(self, value, type_: kernelNDArrayT, span):
         super().__init__("const", type_, span)
+        self.value = value
         self.script_var = _ir.const(value, type_.dtype_str())
 
 

--- a/python/matx/kernel/parser/base_parser.py
+++ b/python/matx/kernel/parser/base_parser.py
@@ -203,6 +203,10 @@ class BaseParser(ast.NodeVisitor):
             raise SyntaxError(f"Annotating {target_name} with type {ann} is not allowed.")
         # make sure the annotated type is the same as rhs value
         if value.kernel_type != ann:
+            if value.kernel_type.shape != ann.shape:
+                raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed because they have different shapes")
+            if value.kernel_type.dtype != ann.dtype:
+                raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed because they have different dtypes")
             raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed")
         tmp_scalar_ctx = ScalarNode(target_name, ann, span)
         self.tmp_scalar_table[target_name] = tmp_scalar_ctx

--- a/python/matx/kernel/parser/base_parser.py
+++ b/python/matx/kernel/parser/base_parser.py
@@ -205,9 +205,10 @@ class BaseParser(ast.NodeVisitor):
         if value.kernel_type != ann:
             if value.kernel_type.shape != ann.shape:
                 raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed because they have different shapes")
-            if value.kernel_type.dtype != ann.dtype:
-                raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed because they have different dtypes")
-            raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed")
+            elif value.kernel_type.dtype != ann.dtype:
+                value = CastOp(value, ann.dtype, span)
+            else:
+                raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed")
         tmp_scalar_ctx = ScalarNode(target_name, ann, span)
         self.tmp_scalar_table[target_name] = tmp_scalar_ctx
         return ScalarAllocationNode(tmp_scalar_ctx, value, span)

--- a/python/matx/kernel/parser/base_parser.py
+++ b/python/matx/kernel/parser/base_parser.py
@@ -204,7 +204,8 @@ class BaseParser(ast.NodeVisitor):
         # make sure the annotated type is the same as rhs value
         if value.kernel_type != ann:
             if value.kernel_type.shape != ann.shape:
-                raise SyntaxError(f"Assigning {value.kernel_type} to {ann} is not allowed because they have different shapes")
+                raise SyntaxError(
+                    f"Assigning {value.kernel_type} to {ann} is not allowed because they have different shapes")
             elif value.kernel_type.dtype != ann.dtype:
                 value = CastOp(value, ann.dtype, span)
             else:

--- a/python/matx/kernel/typing/kernel_type.py
+++ b/python/matx/kernel/typing/kernel_type.py
@@ -58,11 +58,11 @@ class NDArrayType:
         return ScalarType(self.dtype)
 
     def __eq__(self, other):
-        return self.shape == other.shape and self.dtype == self.dtype
+        return self.shape == other.shape and self.dtype == other.dtype
 
     def compatible_with(self, other):
         # todo check dtype
-        return self.shape == other and self.dtype == self.dtype
+        return self.shape == other.shape and self.dtype == other.dtype
 
 
 class ScalarType(NDArrayType):

--- a/python/matx/kernel/typing/kernel_type.py
+++ b/python/matx/kernel/typing/kernel_type.py
@@ -43,7 +43,7 @@ NPDTYPE_TO_STR = {
 
 class NDArrayType:
     def __init__(self, shape, dtype):
-        self.shape = shape
+        self.shape = tuple(shape)
         self.dtype = dtype
         self.storage = 'cpu'
         self.symbol_list = [axis for axis in shape if is_symbol(axis)]
@@ -68,7 +68,7 @@ class NDArrayType:
 class ScalarType(NDArrayType):
 
     def __init__(self, dtype):
-        super().__init__([1], dtype)
+        super().__init__((1, ), dtype)
 
     def __getitem__(self, shape) -> NDArrayType:
         if isinstance(shape, list) or isinstance(shape, tuple):

--- a/python/matx/kernel/typing/utils.py
+++ b/python/matx/kernel/typing/utils.py
@@ -52,7 +52,7 @@ def is_scalar_type(t):
 
 def get_dtype(x):
     if isinstance(x, bool):
-        return bool
+        return np.bool_
     if isinstance(x, int):
         return np.int64
     if isinstance(x, float):

--- a/src/ir/printer/kernel_printer/linalg_generic_printer.cc
+++ b/src/ir/printer/kernel_printer/linalg_generic_printer.cc
@@ -213,7 +213,7 @@ void LinalgGenericPrinter::VisitComputBlockBody_(const matxscript::ir::Stmt& bod
     const int idx =
         std::find(regionArray.begin(), regionArray.end(), bufferRegionPtr) - regionArray.begin();
     element_name = "%_" + element_name + std::to_string(idx);
-    mlir_printer_->insert_or_assign_expr_name_map_(bufferRegionPtr, element_name);
+    mlir_printer_->insert_or_assign_map_(mlir_printer_->expr_name_map_, static_cast<const Object*>(bufferRegionPtr), element_name);
     os << element_name << ": " << mlir_printer_->ConvertTypeToMLIR(buffer->dtype);
     if (i != bufferRegionOrder.size() - 1) {
       os << ", ";

--- a/src/ir/printer/kernel_printer/linalg_generic_printer.cc
+++ b/src/ir/printer/kernel_printer/linalg_generic_printer.cc
@@ -23,6 +23,7 @@
  * \brief Printer to print out the unified IR text format
  *        that can be parsed by a parser.
  */
+#include "matxscript/ir/printer/kernel_printer/linalg_generic_printer.h"
 #include <iostream>
 #include <ostream>
 #include <sstream>
@@ -33,7 +34,6 @@
 #include "matxscript/ir/prim_expr.h"
 #include "matxscript/ir/prim_ops.h"
 #include "matxscript/ir/prim_var.h"
-#include "matxscript/ir/printer/kernel_printer/linalg_generic_printer.h"
 #include "matxscript/ir/tensor_stmt.h"
 #include "matxscript/ir/type.h"
 #include "matxscript/runtime/dlpack.h"
@@ -213,7 +213,8 @@ void LinalgGenericPrinter::VisitComputBlockBody_(const matxscript::ir::Stmt& bod
     const int idx =
         std::find(regionArray.begin(), regionArray.end(), bufferRegionPtr) - regionArray.begin();
     element_name = "%_" + element_name + std::to_string(idx);
-    mlir_printer_->insert_or_assign_map_(mlir_printer_->expr_name_map_, static_cast<const Object*>(bufferRegionPtr), element_name);
+    mlir_printer_->insert_or_assign_map_(
+        mlir_printer_->expr_name_map_, static_cast<const Object*>(bufferRegionPtr), element_name);
     os << element_name << ": " << mlir_printer_->ConvertTypeToMLIR(buffer->dtype);
     if (i != bufferRegionOrder.size() - 1) {
       os << ", ";

--- a/src/ir/printer/kernel_printer/linalg_generic_printer.cc
+++ b/src/ir/printer/kernel_printer/linalg_generic_printer.cc
@@ -23,7 +23,6 @@
  * \brief Printer to print out the unified IR text format
  *        that can be parsed by a parser.
  */
-#include "matxscript/ir/printer/kernel_printer/linalg_generic_printer.h"
 #include <iostream>
 #include <ostream>
 #include <sstream>
@@ -34,6 +33,7 @@
 #include "matxscript/ir/prim_expr.h"
 #include "matxscript/ir/prim_ops.h"
 #include "matxscript/ir/prim_var.h"
+#include "matxscript/ir/printer/kernel_printer/linalg_generic_printer.h"
 #include "matxscript/ir/tensor_stmt.h"
 #include "matxscript/ir/type.h"
 #include "matxscript/runtime/dlpack.h"

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -62,19 +62,23 @@ using namespace ::matxscript::runtime;
 void MLIRTextPrinter::NewScope() {
   expr_name_scope.emplace_back(expr_name_map_->begin(), expr_name_map_->end());
   expr_name_map_ = &(expr_name_scope.back());
-  var_type_scope.emplace_back(val_type_map_->begin(), val_type_map_->end());
-  val_type_map_ = &(var_type_scope.back());
+  val_type_scope.emplace_back(val_type_map_->begin(), val_type_map_->end());
+  val_type_map_ = &(val_type_scope.back());
   var_name_scope.emplace_back(var_name_map_->begin(), var_name_map_->end());
   var_name_map_ = &(var_name_scope.back());
+  var_type_scope.emplace_back(var_type_map_->begin(), var_type_map_->end());
+  var_type_map_ = &(var_type_scope.back());
 }
 
 void MLIRTextPrinter::PopScope() {
   expr_name_scope.pop_back();
   expr_name_map_ = &(expr_name_scope.back());
-  var_type_scope.pop_back();
-  val_type_map_ = &(var_type_scope.back());
+  val_type_scope.pop_back();
+  val_type_map_ = &(val_type_scope.back());
   var_name_scope.pop_back();
   var_name_map_ = &(var_name_scope.back());
+  var_type_scope.pop_back();
+  var_type_map_ = &(var_type_scope.back());
 }
 
 // Error Handlers
@@ -97,7 +101,7 @@ void MLIRTextPrinter::VisitExpr_(const IntImmNode* op, std::ostream& os) {
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_, static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -107,7 +111,7 @@ void MLIRTextPrinter::VisitExpr_(const FloatImmNode* op, std::ostream& os) {
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -259,7 +263,7 @@ void MLIRTextPrinter::GenMLIRArithStatement(
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -295,7 +299,7 @@ void MLIRTextPrinter::VisitExpr_(const PrimFloorDivNode* op, std::ostream& os) {
   }
   const std::string var_name = '%' + std::to_string(cur_index_);
   os << var_name << " = math.floor " << expr_name_map_->at(op) << " : " << data_type << std::endl;
-  insert_or_assign_expr_name_map_(op, var_name);
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), var_name);
   cur_index_++;
 }
 
@@ -307,7 +311,7 @@ void MLIRTextPrinter::VisitExpr_(const PrimFloorModNode* op, std::ostream& os) {
   PrimAdd add(normal_mod, rhs);
   PrimMod mod2(add, rhs);
   VisitExpr_(mod2.get(), os);
-  insert_or_assign_expr_name_map_(op, expr_name_map_->at(mod2.get()));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), expr_name_map_->at(mod2.get()));
   expr_name_map_->erase(normal_mod.get());
   expr_name_map_->erase(add.get());
   expr_name_map_->erase(mod2.get());
@@ -362,7 +366,7 @@ void MLIRTextPrinter::GenMLIRCompareStatement(const std::string& compare_type,
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -411,7 +415,7 @@ void MLIRTextPrinter::VisitExpr_(const PrimAndNode* op, std::ostream& os) {
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -435,7 +439,7 @@ void MLIRTextPrinter::VisitExpr_(const PrimOrNode* op, std::ostream& os) {
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -454,7 +458,7 @@ void MLIRTextPrinter::VisitExpr_(const PrimNotNode* op, std::ostream& os) {
   if (expr_name_map_->find(op) != expr_name_map_->end()) {
     MXTHROW << "[linalg] op is already in expr_index_map_";
   }
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
@@ -551,12 +555,12 @@ void MLIRTextPrinter::VisitExpr_(const PrimCastNode* op, std::ostream& os) {
   os << " : ";
   os << ConvertTypeToMLIR(v->checked_type()) << " to " << ConvertTypeToMLIR(op->checked_type())
      << std::endl;
-  insert_or_assign_expr_name_map_(op, '%' + std::to_string(cur_index_));
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op), '%' + std::to_string(cur_index_));
   cur_index_ += 1;
 }
 
 void MLIRTextPrinter::VisitExpr_(const BufferLoadNode* op, std::ostream& os) {
-  insert_or_assign_expr_name_map_(op, computeBlockPrinter->GetPrimVarName(op));
+  insert_or_assign_map_(expr_name_map_, static_cast<const Object*>(op), computeBlockPrinter->GetPrimVarName(op));
 }
 
 // Begin Stmt
@@ -585,7 +589,7 @@ void MLIRTextPrinter::VisitStmt_(const AllocaVarStmtNode* op, std::ostream& os) 
     MXTHROW << "The init value of " << op << " is not a PrimExpr.";
     return;
   }
-  insert_or_assign_var_name_map_(node_name, expr_name_map_->at(init_value.get()));
+  insert_or_assign_map_(var_name_map_, std::move(node_name), expr_name_map_->at(init_value.get()));
 }
 
 void MLIRTextPrinter::VisitStmt_(const AssignStmtNode* op, std::ostream& os) {
@@ -607,7 +611,7 @@ void MLIRTextPrinter::VisitStmt_(const AssignStmtNode* op, std::ostream& os) {
     MXTHROW << "The init value of " << op << " is not a PrimExpr.";
     return;
   }
-  insert_or_assign_var_name_map_(node_name, expr_name_map_->at(rhs_expr.get()));
+  insert_or_assign_map_(var_name_map_, std::move(node_name), expr_name_map_->at(rhs_expr.get()));
 }
 
 void MLIRTextPrinter::VisitStmt_(const ReturnStmtNode* op, std::ostream& os) {
@@ -631,6 +635,21 @@ void MLIRTextPrinter::VisitStmt_(const AssertStmtNode* op, std::ostream& os) {
   VisitStmtDefault_(op, os);
 }
 
+
+auto SearchCommonNewVars(const MLIRTextPrinter::var_name_map &if_case,
+                         const MLIRTextPrinter::var_name_map &else_case,
+                         const MLIRTextPrinter::var_name_map &old_vars){
+  std::unordered_map<StringRef, std::pair<std::string, std::string>> common_new_vars;
+  for (const auto &pair:if_case){
+    if(else_case.count(pair.first) && !old_vars.count(pair.first)){
+      MXCHECK(common_new_vars.find(pair.first)== common_new_vars.end())<<"[MLIR Printer] "<<pair.first;
+      std::pair<std::string, std::string> names(pair.second, else_case.at(pair.first));
+      common_new_vars.emplace(pair.first, std::move(names));
+    }
+  }
+  return common_new_vars;
+}
+
 void MLIRTextPrinter::VisitStmt_(const IfThenElseNode* op, std::ostream& os) {
   MXCHECK(op->condition->IsInstance<PrimExprNode>())
       << "The condition of if op: " << op << " is not a PrimExprNode";
@@ -638,11 +657,58 @@ void MLIRTextPrinter::VisitStmt_(const IfThenElseNode* op, std::ostream& os) {
   const auto& then_case = op->then_case;
   const auto& else_case = op->else_case;
   PrimExprFunctor::VisitExpr(condition, os);
-  os << "scf.if " << expr_name_map_->at(condition.get()) << " {" << std::endl;
-  VisitStmt(then_case, os);
-  os << "} else {" << std::endl;
-  VisitStmt(else_case, os);
-  os << "}" << std::endl;
+  std::stringstream true_block, false_block;
+  const auto &current_vars = var_name_scope.back();
+  this->NewScope();
+  VisitStmt(then_case, true_block);
+  const auto true_new_vars = var_name_scope.back();
+  this->PopScope();
+  this->NewScope();
+  VisitStmt(then_case, false_block);
+  const auto false_new_vars = var_name_scope.back();
+  this->PopScope();
+
+  const auto & common_new_vars = SearchCommonNewVars(true_new_vars, false_new_vars, current_vars);
+  if(common_new_vars.empty()) {
+    os << "scf.if " << expr_name_map_->at(condition.get()) << " {" << std::endl;
+    os << true_block.rdbuf();
+    os << "} else {" << std::endl;
+    os << false_block.rdbuf();
+    os << "}" << std::endl;
+  } else {
+    std::vector<StringRef> py_var_names;
+    std::vector<std::string> type_info;
+    for(const auto& k_v : common_new_vars) {
+      StringRef key = k_v.first;
+      const auto& value = k_v.second;
+      // assign a new mlir var name to the python variable
+      const std::string name = '%' + std::to_string(cur_index_);
+      cur_index_++;
+      insert_or_assign_map_(var_name_map_, key, name);
+      py_var_names.push_back(std::move(key));
+      //type_info.push_back(ConvertTypeToMLIR())
+    }
+    // pass the var out
+    for(size_t i=0; i<py_var_names.size(); i++){
+      const auto &mlir_name = var_name_map_->at(py_var_names.at(i));
+      os<<py_var_names.at(i);
+      if(i!=py_var_names.size()-1){
+        os<<", ";
+      } else {
+        os<<" = " "scf.if " << expr_name_map_->at(condition.get());
+        os<<" -> (f32, f32)"<<std::endl;
+        os<< " {" << std::endl;
+      }
+    }
+    // print the if block
+    os << true_block.rdbuf();
+    os << "scf.yield %x_true, %y_true : f32, f32";
+    os << "} else {" << std::endl;
+    // print the else block
+    os << false_block.rdbuf();
+    os << "scf.yield %x_true, %y_true : f32, f32";
+    os << "}" << std::endl;
+  }
 }
 
 void MLIRTextPrinter::VisitStmt_(const SeqStmtNode* op, std::ostream& os) {
@@ -689,7 +755,7 @@ void MLIRTextPrinter::VisitStmt_(const PrimFuncNode* op, std::ostream& os) {
       auto node = runtime::Downcast<PrimVar>(param);
       os << '%' << node->name_hint << ": ";
       VisitType(node->checked_type(), os);
-      insert_or_assign_expr_name_map_(param.get(), '%' + std::string(node->name_hint.data()));
+      insert_or_assign_map_(expr_name_map_, static_cast<const Object*>(param.get()), '%' + std::string(node->name_hint.data()));
     } else {
       MXTHROW << "[linalg] not support arg node: " << param->checked_type();
     }
@@ -781,7 +847,7 @@ void MLIRTextPrinter::VisitStmt_(const AllocateNode* op, std::ostream& os) {
     }
   }
   os << ") : " << type_str << std::endl;
-  insert_or_assign_expr_name_map_(op->buffer_var.get(), var_name);
+  insert_or_assign_map_(expr_name_map_,static_cast<const Object*>(op->buffer_var.get()), var_name);
   VisitStmt(op->body, os);
 }
 

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -191,8 +191,9 @@ void MLIRTextPrinter::PrintNodeName(const BaseExpr& ptr, std::ostream& os) {
   }
   if (ptr->IsInstance<PrimVarNode>()) {
     auto node = runtime::Downcast<PrimVar>(ptr);
-    const auto & var_name = var_name_map_->find(node->name_hint);
-    MXCHECK(var_name!=var_name_map_->end())<< "Expr: " << ptr << " has no corrresponding ssa value";
+    const auto& var_name = var_name_map_->find(node->name_hint);
+    MXCHECK(var_name != var_name_map_->end())
+        << "Expr: " << ptr << " has no corrresponding ssa value";
     os << var_name->second;
     return;
   }
@@ -460,7 +461,6 @@ void MLIRTextPrinter::VisitExpr_(const PrimNotNode* op, std::ostream& os) {
 void MLIRTextPrinter::VisitExpr_(const PrimSelectNode* op, std::ostream& os) {
   //%x = arith.select %cond, %true, %false : i32
   VisitStmtDefault_(op, os);
-
 }
 
 void MLIRTextPrinter::VisitExpr_(const PrimVarNode* op, std::ostream& os) {
@@ -569,24 +569,24 @@ void MLIRTextPrinter::VisitStmt_(const BufferStoreNode* op, std::ostream& os) {
 
 void MLIRTextPrinter::VisitStmt_(const AllocaVarStmtNode* op, std::ostream& os) {
   if (expr_name_map_->find(op->var.get()) != expr_name_map_->end()) {
-    MXTHROW<< "Allocating var "<< op->var <<" which has already been allocated.";
+    MXTHROW << "Allocating var " << op->var << " which has already been allocated.";
     return;
   }
-  const auto & name = op->var;
+  const auto& name = op->var;
   StringRef node_name;
   if (name->IsInstance<PrimVarNode>()) {
-    const auto &node = runtime::Downcast<PrimVar>(name);
+    const auto& node = runtime::Downcast<PrimVar>(name);
     node_name = node->name_hint;
   } else {
-    MXTHROW<< "The target var of "<< op <<" is not a PrimVar.";
+    MXTHROW << "The target var of " << op << " is not a PrimVar.";
     return;
   }
-  const auto & init_value = op->init_value;
-  if(init_value->IsInstance<PrimExprNode>()){
-    const auto &node = runtime::Downcast<PrimExpr>(init_value);
+  const auto& init_value = op->init_value;
+  if (init_value->IsInstance<PrimExprNode>()) {
+    const auto& node = runtime::Downcast<PrimExpr>(init_value);
     PrimExprFunctor::VisitExpr(node, os);
-  }else {
-    MXTHROW<< "The init value of "<< op <<" is not a PrimExpr.";
+  } else {
+    MXTHROW << "The init value of " << op << " is not a PrimExpr.";
     return;
   }
   insert_or_assign_var_name_map_(node_name, expr_name_map_->at(init_value.get()));

--- a/src/ir/printer/kernel_printer/mlir_printer.cc
+++ b/src/ir/printer/kernel_printer/mlir_printer.cc
@@ -62,8 +62,6 @@ using namespace ::matxscript::runtime;
 void MLIRTextPrinter::NewScope() {
   expr_name_scope.emplace_back(expr_name_map_->begin(), expr_name_map_->end());
   expr_name_map_ = &(expr_name_scope.back());
-  val_type_scope.emplace_back(val_type_map_->begin(), val_type_map_->end());
-  val_type_map_ = &(val_type_scope.back());
   var_name_scope.emplace_back(var_name_map_->begin(), var_name_map_->end());
   var_name_map_ = &(var_name_scope.back());
 }
@@ -71,8 +69,6 @@ void MLIRTextPrinter::NewScope() {
 void MLIRTextPrinter::PopScope() {
   expr_name_scope.pop_back();
   expr_name_map_ = &(expr_name_scope.back());
-  val_type_scope.pop_back();
-  val_type_map_ = &(val_type_scope.back());
   var_name_scope.pop_back();
   var_name_map_ = &(var_name_scope.back());
 }
@@ -202,12 +198,8 @@ void MLIRTextPrinter::PrintNodeName(const BaseExpr& ptr, std::ostream& os) {
   MXTHROW << "Expr: " << ptr << " has no corrresponding ssa value";
 }
 
-std::pair<std::string, std::string> MLIRTextPrinter::GetNodeDataType(const PrimExprNode* op) {
-  auto val_type_iter = val_type_map_->find(op);
-  if (val_type_iter != val_type_map_->end()) {
-    return val_type_iter->second;
-  }
-  std::string arith_suffix = "";
+std::pair<std::string, std::string> MLIRTextPrinter::GetNodeDataType(const PrimExprNode* op) const {
+  std::string arith_suffix;
   std::string data_type = ConvertTypeToMLIR(op->checked_type());
   MXCHECK(op->dtype.lanes() == 1) << " lanes must be 1, but receive " << op->dtype.lanes();
   auto op_dtype = op->dtype.code();
@@ -224,14 +216,13 @@ std::pair<std::string, std::string> MLIRTextPrinter::GetNodeDataType(const PrimE
       MXTHROW << "data type not supported, type: " << op->dtype.code() << " bits: " << bits;
   }
 
-  if (arith_suffix == "" || data_type == "") {
+  if (arith_suffix.empty() || data_type.empty()) {
     MXTHROW << "data type not supported, type: " << op->dtype.code()
             << " bits: " << op->dtype.bits();
   }
 
   auto node_data_type =
       std::make_pair<std::string, std::string>(std::move(data_type), std::move(arith_suffix));
-  val_type_map_->emplace(op, node_data_type);
   return node_data_type;
 }
 

--- a/test/kernel/test_kernel_single_return_parser.py
+++ b/test/kernel/test_kernel_single_return_parser.py
@@ -18,12 +18,12 @@
 #  under the License.
 
 import unittest
-import numpy as np
+
 import sympy
 
-from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
-from matx.kernel.typing import int32, int64, float32
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.typing import *
 
 
 class TestSingleReturnParser(unittest.TestCase):
@@ -175,7 +175,7 @@ class TestSingleReturnParser(unittest.TestCase):
         M = sympy.Symbol('M', positive=True)
         N = sympy.Symbol('N', positive=True)
 
-        def foo(a: int32[M, N], b: int64[M, N], c: float32[M, N]) -> float32[M, N]:
+        def foo(a: int32[M, N], b: int64[M, N], c: float32[M, N]) -> float64[M, N]:
             return (a + b) * c
 
         p = KernelParser(foo)
@@ -190,7 +190,7 @@ class TestSingleReturnParser(unittest.TestCase):
         a = np.arange(12, dtype=np.int32).reshape(3, 4)
         b = np.arange(12, 24, dtype=np.int64).reshape(3, 4)
         c = np.arange(24, 36, dtype=np.float32).reshape(3, 4)
-        rt = np.zeros(a.shape, dtype=np.float32)
+        rt = np.zeros(a.shape, dtype=np.float64)
         f = compile_linalg(p)
         f(a, b, c, rt=rt)
         np.testing.assert_equal(rt, foo(a, b, c))
@@ -199,7 +199,7 @@ class TestSingleReturnParser(unittest.TestCase):
         M = sympy.Symbol('M', positive=True)
         N = sympy.Symbol('N', positive=True)
 
-        def foo(a: int32[M, N], b: int64[M, N], c: float32) -> float32[M, N]:
+        def foo(a: int32[M, N], b: int64[M, N], c: float32) -> float64[M, N]:
             return ((a + b) * c) + 1
 
         p = KernelParser(foo)
@@ -214,7 +214,7 @@ class TestSingleReturnParser(unittest.TestCase):
         a = np.arange(12, dtype=np.int32).reshape(3, 4)
         b = np.arange(12, 24, dtype=np.int64).reshape(3, 4)
         c = np.float32(3)
-        rt = np.zeros(a.shape, dtype=np.float32)
+        rt = np.zeros(a.shape, dtype=np.float64)
         f = compile_linalg(p)
         f(a, b, c, rt=rt)
         np.testing.assert_equal(rt, foo(a, b, c))

--- a/test/kernel/test_scalar_arithmetic_op.py
+++ b/test/kernel/test_scalar_arithmetic_op.py
@@ -19,9 +19,9 @@
 
 import unittest
 
-from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
-from matx.kernel.typing import int32, float32, float64, boolean
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.typing import int32, float32, float64
 
 
 class TestMLIRIntArithmeticOp(unittest.TestCase):
@@ -272,7 +272,7 @@ class TestMLIRMixedArithmeticOp(unittest.TestCase):
         def foo2(a: float64, b: int32) -> float64:
             return a + b
 
-        def foo3(a: float32, b: int32) -> float32:
+        def foo3(a: float32, b: int32) -> float64:
             return a + b
 
         self.foo1 = self.helper(foo1)
@@ -291,7 +291,7 @@ class TestMLIRMixedArithmeticOp(unittest.TestCase):
         def foo2(a: float64, b: int32) -> float64:
             return a - b
 
-        def foo3(a: float32, b: int32) -> float32:
+        def foo3(a: float32, b: int32) -> float64:
             return a - b
 
         self.foo1 = self.helper(foo1)
@@ -310,7 +310,7 @@ class TestMLIRMixedArithmeticOp(unittest.TestCase):
         def foo2(a: float64, b: int32) -> float64:
             return a * b
 
-        def foo3(a: float32, b: int32) -> float32:
+        def foo3(a: float32, b: int32) -> float64:
             return a * b
 
         self.foo1 = self.helper(foo1)

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -86,8 +86,8 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
         k_foo = self.helper(foo)
         for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
             self.assertEqual(foo(x, y, z), k_foo(x, y, z))
-"""
-    def test_scalar_if(self):
+
+    def test_scalar_if1(self):
         def foo(a: int32, b: int32, c: int32) -> int32:
             if a % 2 == 0:
                 d: int32 = b + c
@@ -97,8 +97,52 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
 
         k_foo = self.helper(foo)
         for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
-            self.assertEqual(foo(x, y, z), k_foo(x, y, z))"""
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
 
+    def test_scalar_if2(self):
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            if a % 2 == 0:
+                i: int32 = a % 3
+                d: int32 = b + c + i
+            else:
+                i: int32 = a % 4
+                d: int32 = b - c + i
+            return d
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+    def test_scalar_if3(self):
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            if a % 2 == 0:
+                i: int32 = a % 3
+                d: int32 = b + c + i
+            else:
+                j: int32 = a % 4
+                d: int32 = b - c + j
+            return d
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+
+"""
+    def test_scalar_if4(self):
+        def foo(a: int32, b: int32, c: int32) -> float64:
+            if a % 2 == 0:
+                i: int32 = a % 3
+                d: float64 = b + c / i
+            else:
+                i: float64 = a / 4
+                d: float64 = b - c / i
+            return d
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+"""
 
 if __name__ == "__main__":
     import logging

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -17,12 +17,12 @@
 #  specific language governing permissions and limitations
 #  under the License.
 
-import unittest
 import itertools
+import unittest
 
-from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
-from matx.kernel.typing import int32, float32, float64, boolean
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.typing import int32, float32, float64
 
 
 class TestMLIRIntArithmeticOp(unittest.TestCase):
@@ -49,7 +49,7 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
             self.assertEqual(foo(x, y), k_foo(x, y))
 
     def test_mixed_assign(self):
-        def foo(a: int32, b: float32) -> float32:
+        def foo(a: int32, b: float32) -> float64:
             c: float32 = a + b
             return a - c
 

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -86,6 +86,18 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
         k_foo = self.helper(foo)
         for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
             self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+"""
+    def test_scalar_if(self):
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            if a % 2 == 0:
+                d: int32 = b + c
+            else:
+                d: int32 = b - c
+            return d
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))"""
 
 
 if __name__ == "__main__":

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -1,0 +1,54 @@
+#  Copyright 2023 ByteDance Ltd. and/or its affiliates.
+#
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing,
+#  software distributed under the License is distributed on an
+#  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+#  KIND, either express or implied.  See the License for the
+#  specific language governing permissions and limitations
+#  under the License.
+
+import unittest
+
+from matx.kernel.kernel_parser import KernelParser
+from matx.kernel.compile_linalg import compile_linalg
+from matx.kernel.typing import int32, float32, float64, boolean
+
+
+class TestMLIRIntArithmeticOp(unittest.TestCase):
+    def helper(self, foo):
+        p = KernelParser(foo)
+        p.parse()
+        print()
+        print("=" * 30, "linalg_code", "=" * 30, sep="")
+        print()
+        print(p.linalg_code())
+        print()
+        print("=" * 30, "compile and run", "=" * 30, sep="")
+        print()
+        f = compile_linalg(p)
+        return f
+
+    def test_int_add(self):
+        def foo(a: int32, b: int32) -> int32:
+            c:int32 = a+b
+            return a + c
+
+        foo = self.helper(foo)
+
+
+if __name__ == "__main__":
+    import logging
+
+    logging.basicConfig(level=logging.INFO)
+    unittest.main()
+    

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -41,7 +41,7 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
 
     def test_int_assign(self):
         def foo(a: int32, b: int32) -> int32:
-            c:int32 = a+b
+            c: int32 = a + b
             return a - c
 
         k_foo = self.helper(foo)
@@ -50,7 +50,7 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
 
     def test_mixed_assign(self):
         def foo(a: int32, b: float32) -> float32:
-            c:float32 = a+b
+            c: float32 = a + b
             return a - c
 
         k_foo = self.helper(foo)
@@ -58,9 +58,9 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
             self.assertEqual(foo(x, y), k_foo(x, y))
 
     def test_int_reassign1(self):
-        def foo(a: int32, b: int32, c:int32) -> int32:
-            c1:int32 = b * c
-            c1:int32 = 1 + c1
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            c1: int32 = b * c
+            c1: int32 = 1 + c1
             return a + b - c1
 
         k_foo = self.helper(foo)
@@ -68,8 +68,8 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
             self.assertEqual(foo(x, y, z), k_foo(x, y, z))
 
     def test_int_reassign2(self):
-        def foo(a: int32, b: int32, c:int32) -> int32:
-            c1:int32 = b * c
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            c1: int32 = b * c
             c1 = 1 + c1
             return a + b - c1
 
@@ -77,11 +77,10 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
         for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
             self.assertEqual(foo(x, y, z), k_foo(x, y, z))
 
-
     def test_int_reassign3(self):
-        def foo(a: int32, b: int32, c:int32) -> int32:
-            c1:int32 = b * c
-            c2:int32 = 1 + c1
+        def foo(a: int32, b: int32, c: int32) -> int32:
+            c1: int32 = b * c
+            c2: int32 = 1 + c1
             return a + b - c2
 
         k_foo = self.helper(foo)
@@ -94,4 +93,3 @@ if __name__ == "__main__":
 
     logging.basicConfig(level=logging.INFO)
     unittest.main()
-    

--- a/test/kernel/test_scalar_functions.py
+++ b/test/kernel/test_scalar_functions.py
@@ -18,6 +18,7 @@
 #  under the License.
 
 import unittest
+import itertools
 
 from matx.kernel.kernel_parser import KernelParser
 from matx.kernel.compile_linalg import compile_linalg
@@ -38,12 +39,54 @@ class TestMLIRIntArithmeticOp(unittest.TestCase):
         f = compile_linalg(p)
         return f
 
-    def test_int_add(self):
+    def test_int_assign(self):
         def foo(a: int32, b: int32) -> int32:
             c:int32 = a+b
-            return a + c
+            return a - c
 
-        foo = self.helper(foo)
+        k_foo = self.helper(foo)
+        for x, y in itertools.product([-50, -1, 0, 6, 32], repeat=2):
+            self.assertEqual(foo(x, y), k_foo(x, y))
+
+    def test_mixed_assign(self):
+        def foo(a: int32, b: float32) -> float32:
+            c:float32 = a+b
+            return a - c
+
+        k_foo = self.helper(foo)
+        for x, y in itertools.product([-50, -1, 0, 6, 32], repeat=2):
+            self.assertEqual(foo(x, y), k_foo(x, y))
+
+    def test_int_reassign1(self):
+        def foo(a: int32, b: int32, c:int32) -> int32:
+            c1:int32 = b * c
+            c1:int32 = 1 + c1
+            return a + b - c1
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+    def test_int_reassign2(self):
+        def foo(a: int32, b: int32, c:int32) -> int32:
+            c1:int32 = b * c
+            c1 = 1 + c1
+            return a + b - c1
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
+
+
+    def test_int_reassign3(self):
+        def foo(a: int32, b: int32, c:int32) -> int32:
+            c1:int32 = b * c
+            c2:int32 = 1 + c1
+            return a + b - c2
+
+        k_foo = self.helper(foo)
+        for x, y, z in itertools.product([-50, -1, 0, 6, 32], repeat=3):
+            self.assertEqual(foo(x, y, z), k_foo(x, y, z))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- support scalar allocation & assignment
- fixed a bug causing binop of constant and non-constant having unexpected dtype
- added a castop when the annotated type does not match numpy calculated type
- fixed a type infer bug related to div op
- support passing variables out from if block in MLIR codegen
- deleted some unnecessary code